### PR TITLE
Use the same TorConfig for bouncer and collector

### DIFF
--- a/oonib/api.py
+++ b/oonib/api.py
@@ -22,6 +22,6 @@ if config.main.policy_file:
     ooniBackendAPI += policyAPI
 
 if config.main.bouncer_file:
-    ooniBouncer = web.Application(bouncerAPI, debug=True)
+    ooniBouncer = web.Application(bouncerAPI, debug=True, name='bouncer')
 
-ooniBackend = web.Application(ooniBackendAPI, debug=True)
+ooniBackend = web.Application(ooniBackendAPI, debug=True, name='collector')


### PR DESCRIPTION
The TorConfig object must be the same or else only the last instance is
used.
