### PR TITLE
Add required package dependency libsqlite3-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ There are a few dependencies which we recommend you get from your
 distribution's archives.
 
 ```
-sudo apt-get install build-essential python-dev python-setuptools openssl
+sudo apt-get install build-essential python-dev python-setuptools openssl libsqlite3-dev
 ```
 
 ### Tor


### PR DESCRIPTION
SQLite 3 development files are needed in order to successfully install
ooni-backend.
Error message while installing 'pip install -r requirements.txt'
'src/connection.h:33:21: fatal error: sqlite3.h: No such file or
directory'
