### PR TITLE
Fix memory leak inside of update report handler.

### DIFF
--- a/oonib/report/api.py
+++ b/oonib/report/api.py
@@ -2,6 +2,7 @@ from oonib.report import handlers
 
 reportAPI = [
     (r"/report/([a-zA-Z0-9_\-]+)/close", handlers.CloseReportHandlerFile),
+    (r"/report/([a-zA-Z0-9_\-]+)", handlers.UpdateReportHandlerFile),
     (r"/report", handlers.NewReportHandlerFile),
     (r"/pcap", handlers.PCAPReportHandler),
 ]


### PR DESCRIPTION
The issue was with the fact that we were not cancelling the delayed calls
therefore they would stay hanging until the stale time was reached. This meant
that when a lot of reporting was happening there would be N hanging delayed
calls while there should only be one.

We were also not deleting the items of the reports dict after we were done with them.

This fixes: https://github.com/TheTorProject/ooni-backend/issues/28
