### PR TITLE
Make the priority list public

### DIFF
--- a/api/debian/changelog
+++ b/api/debian/changelog
@@ -1,3 +1,9 @@
+ooni-api (1.0.49) unstable; urgency=medium
+
+  * Make url priorities listing public
+
+ -- Federico Ceratto <federico@debian.org>  Mon, 20 Mar 2023 12:59:54 +0000
+
 ooni-api (1.0.48) unstable; urgency=medium
 
   * Cleanup

--- a/api/ooniapi/citizenlab.py
+++ b/api/ooniapi/citizenlab.py
@@ -794,7 +794,6 @@ def post_propose_changes() -> Response:
 
 
 @cz_blueprint.route("/api/_/url-priorities/list", methods=["GET"])
-@role_required(["admin"])
 def list_url_priorities() -> Response:
     """List URL priority rules
     ---


### PR DESCRIPTION
This is needed so we can allow listing priorities publicly