### PR TITLE
Fix domain listing query

### DIFF
--- a/api/debian/changelog
+++ b/api/debian/changelog
@@ -1,3 +1,9 @@
+ooni-api (1.0.51) unstable; urgency=medium
+
+  * Fix domain listing query
+
+ -- Federico Ceratto <federico@debian.org>  Thu, 23 Mar 2023 18:17:38 +0000
+
 ooni-api (1.0.50) unstable; urgency=medium
 
   * Remove test_name check from list measurements

--- a/api/ooniapi/private.py
+++ b/api/ooniapi/private.py
@@ -989,9 +989,14 @@ def api_private_domains() -> Response:
     q = """
     SELECT domain AS domain_name, category_code, measurement_count
     FROM (
-        SELECT domain, category_code
-        FROM citizenlab
-        GROUP BY domain, category_code
+        SELECT
+        any(category_code) as category_code,
+        domain FROM (
+            SELECT domain, category_code
+            FROM citizenlab
+            ORDER BY cc ASC
+        )
+        GROUP BY domain
     ) AS cz
     LEFT JOIN (
         SELECT domain, count() AS measurement_count

--- a/api/ooniapi/private.py
+++ b/api/ooniapi/private.py
@@ -983,9 +983,8 @@ def api_private_domains() -> Response:
       200:
         description: JSON object
     """
-    # Nested ORDER BY cc ASC
-    # is used to prioritize the category code of a domain in
-    # the global list (cc=ZZ)
+    # The nested ORDER BY lower(cc) puts global entries (cc=ZZ) on top so that
+    # any(category_code) picks it up as the most meaningful category code.
     q = """
     SELECT domain AS domain_name, category_code, measurement_count
     FROM (
@@ -994,7 +993,7 @@ def api_private_domains() -> Response:
         domain FROM (
             SELECT domain, category_code
             FROM citizenlab
-            ORDER BY lower(cc) = 'ZZ' DESC
+            ORDER BY lower(cc) != 'zz'
         )
         GROUP BY domain
     ) AS cz

--- a/api/ooniapi/private.py
+++ b/api/ooniapi/private.py
@@ -994,7 +994,7 @@ def api_private_domains() -> Response:
         domain FROM (
             SELECT domain, category_code
             FROM citizenlab
-            ORDER BY cc ASC
+            ORDER BY lower(cc) = 'ZZ' DESC
         )
         GROUP BY domain
     ) AS cz

--- a/api/tests/integ/test_private_api.py
+++ b/api/tests/integ/test_private_api.py
@@ -341,4 +341,7 @@ def test_private_api_domains(client, log):
     rows = resp["results"]
     assert len(rows) > 5
     assert sorted(rows[0]) == ["category_code", "domain_name", "measurement_count"]
-    assert "twitter.com" in [r["domain_name"] for r in rows]
+    d = {r["domain_name"]: r["category_code"] for r in rows}
+    assert d["facebook.com"] == "GRP"
+    assert d["ncac.org"] == "NEWS"
+    assert d["twitter.com"] == "GRP"


### PR DESCRIPTION
A domain can appear in multiple country lists, so we need to pick the first occurrence of it sorted by country_code (so we give priority to the category code of the domain in the global list).