### PR TITLE
Limit the count of measurements by test_name in domain list

### DIFF
--- a/api/debian/changelog
+++ b/api/debian/changelog
@@ -1,3 +1,9 @@
+ooni-api (1.0.52) unstable; urgency=medium
+
+  * Fix measurement count
+
+ -- Federico Ceratto <federico@debian.org>  Fri, 31 Mar 2023 11:15:22 +0100
+
 ooni-api (1.0.51) unstable; urgency=medium
 
   * Fix domain listing query

--- a/api/ooniapi/private.py
+++ b/api/ooniapi/private.py
@@ -1000,6 +1000,7 @@ def api_private_domains() -> Response:
     LEFT JOIN (
         SELECT domain, count() AS measurement_count
         FROM fastpath
+        WHERE test_name = 'web_connectivity'
         GROUP BY domain
     ) AS fp
     ON (fp.domain == cz.domain)


### PR DESCRIPTION
In the new domain pages we only display measurements coming from web_connectivity, yet in the listing we include in the count also non-web_connectivity measurements.
This PR is to address that so that we only limit it to those measurements.