### PR TITLE
Filter list_measurement by versions

### DIFF
--- a/api/ooniapi/measurements.py
+++ b/api/ooniapi/measurements.py
@@ -690,7 +690,6 @@ def list_measurements() -> Response:
     test_name = param("test_name")
     since = param_date("since")
     until = param_date("until")
-    since_index = param("since_index")  # unused
     order_by = param("order_by")
     order = param("order", "desc")
     offset = int(param("offset", 0))

--- a/api/ooniapi/measurements.py
+++ b/api/ooniapi/measurements.py
@@ -629,21 +629,21 @@ def list_measurements() -> Response:
         type: string
         description: |
           Set "true" for confirmed network anomalies (we found a blockpage, a middlebox, etc.).
-          Default: both true and false
+          Default: no filtering (show both true and false)
 
       - name: anomaly
         in: query
         type: string
         description: |
           Set "true" for measurements that require special attention (likely to be a case of blocking)
-          Default: both true and false
+          Default: no filtering (show both true and false)
 
       - name: failure
         in: query
         type: string
         description: |
           Set "true" for failed measurements (the control request failed, there was a bug, etc.).
-          Default: both true and false
+          Default: no filtering (show both true and false)
 
       - name: software_version
         in: query

--- a/api/ooniapi/measurements.py
+++ b/api/ooniapi/measurements.py
@@ -583,77 +583,66 @@ def list_measurements() -> Response:
       - name: report_id
         in: query
         type: string
-        description: The report_id to search measurements for
+        description: Report_id to search measurements for
       - name: input
         in: query
         type: string
         minLength: 3 # `input` is handled by pg_trgm
-        description: The input (for example a URL or IP address) to search measurements for
+        description: Input (for example a URL or IP address) to search measurements for
       - name: domain
         in: query
         type: string
         minLength: 3
-        description: The domain to search measurements for
+        description: Domain to search measurements for
       - name: probe_cc
         in: query
         type: string
-        description: The two letter country code
+        description: Two letter country code
       - name: probe_asn
         in: query
         type: string
-        description: the Autonomous system number in the format "ASXXX"
+        description: Autonomous system number in the format "ASXXX"
       - name: test_name
         in: query
         type: string
-        description: The name of the test
+        description: Name of the test
       - name: category_code
         in: query
         type: string
-        description: The category code from the citizenlab list
+        description: Category code from the citizenlab list
       - name: since
         in: query
         type: string
         description: >-
-          The start date of when measurements were run (ex.
+          Start date of when measurements were run (ex.
           "2016-10-20T10:30:00")
       - name: until
         in: query
         type: string
         description: >-
-          The end date of when measurement were run (ex.
+          End date of when measurement were run (ex.
           "2016-10-20T10:30:00")
-      - name: since_index
-        in: query
-        type: string
-        description: Return results only strictly greater than the provided index
 
       - name: confirmed
         in: query
         type: string
-        collectionFormat: csv
-        items:
-          type: string
         description: |
-          Will be true for confirmed network anomalies (we found a blockpage, a middlebox was found, the IM app is blocked, etc.).
+          Set "true" for confirmed network anomalies (we found a blockpage, a middlebox, etc.).
+          Default: both true and false
 
       - name: anomaly
         in: query
         type: string
-        collectionFormat: csv
-        items:
-          type: string
         description: |
-          Measurements that require special attention (it's likely to be a case of blocking), however it has not necessarily been confirmed
+          Set "true" for measurements that require special attention (likely to be a case of blocking)
+          Default: both true and false
 
       - name: failure
         in: query
         type: string
-        collectionFormat: csv
-        items:
-          type: string
         description: |
-          There was an error in the measurement (the control request failed, there was a bug, etc.).
-          Default is to consider it both true or false (`failure=true,false`)
+          Set "true" for failed measurements (the control request failed, there was a bug, etc.).
+          Default: both true and false
 
       - name: order_by
         in: query

--- a/api/ooniapi/measurements.py
+++ b/api/ooniapi/measurements.py
@@ -35,6 +35,7 @@ from ooniapi.database import query_click, query_click_one_row
 from ooniapi.urlparams import (
     param_asn,
     param_bool,
+    param_commasplit,
     param_date,
     param_input_or_none,
     param_report_id,
@@ -644,6 +645,21 @@ def list_measurements() -> Response:
           Set "true" for failed measurements (the control request failed, there was a bug, etc.).
           Default: both true and false
 
+      - name: software_version
+        in: query
+        type: string
+        description: Filter measurements by software version. Comma-separated.
+
+      - name: test_version
+        in: query
+        type: string
+        description: Filter measurements by test version. Comma-separated.
+
+      - name: engine_version
+        in: query
+        type: string
+        description: Filter measurements by engine version. Comma-separated.
+
       - name: order_by
         in: query
         type: string
@@ -698,6 +714,9 @@ def list_measurements() -> Response:
     anomaly = param_bool("anomaly")
     confirmed = param_bool("confirmed")
     category_code = param("category_code")
+    software_versions = param_commasplit("software_version")
+    test_versions = param_commasplit("test_version")
+    engine_versions = param_commasplit("engine_version")
 
     # Workaround for https://github.com/ooni/probe/issues/1034
     user_agent = request.headers.get("User-Agent", "")
@@ -787,6 +806,18 @@ def list_measurements() -> Response:
     if test_name is not None:
         query_params["test_name"] = test_name
         fpwhere.append(sql.text("test_name = :test_name"))
+
+    if software_versions is not None:
+        query_params["software_versions"] = software_versions
+        fpwhere.append(sql.text("software_version IN :software_versions"))
+
+    if test_versions is not None:
+        query_params["test_versions"] = test_versions
+        fpwhere.append(sql.text("test_version IN :test_versions"))
+
+    if engine_versions is not None:
+        query_params["engine_versions"] = engine_versions
+        fpwhere.append(sql.text("engine_version IN :engine_versions"))
 
     # Filter on anomaly, confirmed and failure:
     # The database stores anomaly and confirmed as boolean + NULL and stores

--- a/api/ooniapi/urlparams.py
+++ b/api/ooniapi/urlparams.py
@@ -114,6 +114,13 @@ def commasplit(p: str) -> List[str]:
     return sorted(out)
 
 
+def param_commasplit(name) -> Optional[List[str]]:
+    p = request.args.get(name)
+    if not p:
+        return None
+    return commasplit(p)
+
+
 def param_domain_m(name="domain") -> List[str]:
     p = request.args.get(name)
     if not p:

--- a/api/tests/integ/test_integration.py
+++ b/api/tests/integ/test_integration.py
@@ -780,6 +780,27 @@ def test_list_measurements_filter_software_version_nomatch(client):
     assert len(resp["results"]) == 0
 
 
+def test_list_measurements_filter_software_version_empty_value(client):
+    # https://github.com/ooni/backend/issues/15
+    url = "measurements?since=2021-07-09&until=2021-07-10&software_version="
+    resp = api(client, url)
+    assert len(resp["results"]) == 100
+
+
+def test_list_measurements_filter_software_version_single(client):
+    # https://github.com/ooni/backend/issues/15
+    url = "measurements?since=2021-07-09&until=2021-07-10&software_version=0.7.1"
+    resp = api(client, url)
+    assert len(resp["results"]) == 28
+
+
+def test_list_measurements_filter_software_version_multiple(client):
+    # https://github.com/ooni/backend/issues/15
+    url = "measurements?since=2021-07-09&until=2021-07-10&software_version=0.7.1,0.8.1"
+    resp = api(client, url)
+    assert len(resp["results"]) == 31
+
+
 def test_list_measurements_filter_software_version(client):
     # https://github.com/ooni/backend/issues/15
     url = "measurements?since=2021-07-09&until=2021-07-10&software_version=3.9.2"

--- a/api/tests/integ/test_integration.py
+++ b/api/tests/integ/test_integration.py
@@ -774,49 +774,49 @@ def test_list_measurements_ZZ(client):
 
 
 def test_list_measurements_filter_software_version_nomatch(client):
-    # https://github.com/ooni/backend/issues/15
+    # https://github.com/ooni/backend/issues/615
     url = "measurements?since=2021-07-09&until=2021-07-10&software_version=9.9.9"
     resp = api(client, url)
     assert len(resp["results"]) == 0
 
 
 def test_list_measurements_filter_software_version_empty_value(client):
-    # https://github.com/ooni/backend/issues/15
+    # https://github.com/ooni/backend/issues/615
     url = "measurements?since=2021-07-09&until=2021-07-10&software_version="
     resp = api(client, url)
     assert len(resp["results"]) == 100
 
 
 def test_list_measurements_filter_software_version_single(client):
-    # https://github.com/ooni/backend/issues/15
+    # https://github.com/ooni/backend/issues/615
     url = "measurements?since=2021-07-09&until=2021-07-10&software_version=0.7.1"
     resp = api(client, url)
     assert len(resp["results"]) == 28
 
 
 def test_list_measurements_filter_software_version_multiple(client):
-    # https://github.com/ooni/backend/issues/15
+    # https://github.com/ooni/backend/issues/615
     url = "measurements?since=2021-07-09&until=2021-07-10&software_version=0.7.1,0.8.1"
     resp = api(client, url)
-    assert len(resp["results"]) == 31
+    assert len(resp["results"]) == 3
 
 
 def test_list_measurements_filter_software_version(client):
-    # https://github.com/ooni/backend/issues/15
+    # https://github.com/ooni/backend/issues/615
     url = "measurements?since=2021-07-09&until=2021-07-10&software_version=3.9.2"
     resp = api(client, url)
     assert len(resp["results"]) == 100
 
 
 def test_list_measurements_filter_test_version(client):
-    # https://github.com/ooni/backend/issues/15
+    # https://github.com/ooni/backend/issues/615
     url = "measurements?since=2021-07-09&until=2021-07-10&test_version=0.4.0"
     resp = api(client, url)
     assert len(resp["results"]) == 100
 
 
 def test_list_measurements_filter_engine_version(client):
-    # https://github.com/ooni/backend/issues/15
+    # https://github.com/ooni/backend/issues/615
     url = "measurements?since=2021-07-09&until=2021-07-10&engine_version=3.9.2"
     resp = api(client, url)
     assert len(resp["results"]) == 100

--- a/api/tests/integ/test_integration.py
+++ b/api/tests/integ/test_integration.py
@@ -773,6 +773,34 @@ def test_list_measurements_ZZ(client):
     assert resp.status_code == 403
 
 
+def test_list_measurements_filter_software_version_nomatch(client):
+    # https://github.com/ooni/backend/issues/15
+    url = "measurements?since=2021-07-09&until=2021-07-10&software_version=9.9.9"
+    resp = api(client, url)
+    assert len(resp["results"]) == 0
+
+
+def test_list_measurements_filter_software_version(client):
+    # https://github.com/ooni/backend/issues/15
+    url = "measurements?since=2021-07-09&until=2021-07-10&software_version=3.9.2"
+    resp = api(client, url)
+    assert len(resp["results"]) == 100
+
+
+def test_list_measurements_filter_test_version(client):
+    # https://github.com/ooni/backend/issues/15
+    url = "measurements?since=2021-07-09&until=2021-07-10&test_version=0.4.0"
+    resp = api(client, url)
+    assert len(resp["results"]) == 100
+
+
+def test_list_measurements_filter_engine_version(client):
+    # https://github.com/ooni/backend/issues/15
+    url = "measurements?since=2021-07-09&until=2021-07-10&engine_version=3.9.2"
+    resp = api(client, url)
+    assert len(resp["results"]) == 100
+
+
 ## get_measurement ##
 
 


### PR DESCRIPTION
Adds filters for software_version, test_version, engine_version to list measurements
https://ams-pg-test.ooni.org/apidocs/#/default/get_api_v1_measurements
Related to https://github.com/ooni/backend/issues/615