### PR TITLE
Flag torsf msmts from Android 3.8.3 as failed

### DIFF
--- a/fastpath/debian/changelog
+++ b/fastpath/debian/changelog
@@ -1,3 +1,9 @@
+fastpath (0.77) unstable; urgency=medium
+
+  * Flag torsf measurements from Android probe 3.8.3 as failed
+
+ -- Federico Ceratto <federico@debian.org>  Thu, 17 Aug 2023 10:54:38 +0200
+
 fastpath (0.76) unstable; urgency=medium
 
   * Extract test helpers metadata

--- a/fastpath/fastpath/core.py
+++ b/fastpath/fastpath/core.py
@@ -1422,6 +1422,12 @@ def score_torsf(msm: dict) -> dict:
     scores["extra"] = dict(
         bootstrap_time=tk.get("bootstrap_time"), test_runtime=msm.get("test_runtime")
     )
+
+    sw_name = msm.get("software_name", "unknown")
+    sw_version = msm.get("software_version", "unknown")
+    if sw_version == "3.8.3" and sw_name.startswith("ooniprobe-android"):
+        scores["accuracy"] = 0.0
+
     return scores
 
 


### PR DESCRIPTION
Possibly related to https://github.com/ooni/probe/issues/2406