### PR TITLE
Test list HTML debug page

### DIFF
--- a/api/debian/changelog
+++ b/api/debian/changelog
@@ -1,3 +1,9 @@
+ooni-api (1.0.75) unstable; urgency=medium
+
+  * Debug test list using HTML table
+
+ -- Federico Ceratto <federico@debian.org>  Mon, 09 Oct 2023 11:32:34 +0200
+
 ooni-api (1.0.74) unstable; urgency=medium
 
   * Filter measurements by OONIRun ID

--- a/api/ooniapi/prio.py
+++ b/api/ooniapi/prio.py
@@ -357,17 +357,13 @@ def debug_prioritization() -> Response:
     test_items, entries, prio_rules = generate_test_list(
         country_code, category_codes, asn, limit, True
     )
+    d = dict(test_items=test_items, entries=entries, prio_rules=prio_rules)
     if fmt == "JSON":
-        out = cachedjson(
-            "0s", test_items=test_items, entries=entries, prio_rules=prio_rules
-        )
+        out = cachedjson("0s", **d)
     else:
-        out = render_template(
-            "debug_prio.html",
-            test_items=test_items,
-            entries=entries,
-            prio_rules=prio_rules,
-        )
+        html = render_template("debug_prio.html", **d)
+        out = make_response(html)
+
     return out
 
 

--- a/api/ooniapi/prio.py
+++ b/api/ooniapi/prio.py
@@ -332,7 +332,12 @@ def debug_prioritization() -> Response:
         description: Probe ASN
       - name: format
         in: query
-        description: JSON or HTML
+        type: string
+        description: |
+          Output format, HTML (default) or JSON
+        enum:
+          - JSON
+          - HTML
       - name: limit
         in: query
         type: integer

--- a/api/ooniapi/prio.py
+++ b/api/ooniapi/prio.py
@@ -352,7 +352,7 @@ def debug_prioritization() -> Response:
     country_code = (param("probe_cc") or "ZZ").upper()
     category_codes = param_category_codes()
     asn = param_asn("probe_asn") or 0
-    limit = int(param("limit") or -1)
+    limit = int(param("limit") or 9999)
     fmt = (param("format") or "HTML").upper()
     test_items, entries, prio_rules = generate_test_list(
         country_code, category_codes, asn, limit, True

--- a/api/ooniapi/templates/debug_prio.html
+++ b/api/ooniapi/templates/debug_prio.html
@@ -34,10 +34,18 @@
     {% block content_fluid %}
     {% endblock %}
 
-<form>
-  <label>CC</label> <input type="text" name="probe_cc"> <br>
-    <input type="submit" value="Submit">
-</form>
+    <br>
+    <h3>URL prioritization</h3>
+
+    <form>
+      <label>CC</label> <input type="text" name="probe_cc"> <br>
+      <label>category codes</label> <input type="text" name="category_codes"> <br>
+      <label>probe_asn</label> <input type="text" name="probe_asn"> <br>
+      <label>format</label> <input type="text" name="format" value="HTML"> <br>
+      <br>
+      <input type="submit" value="Submit">
+    </form>
+    <br>
 
     <table class="sortable">
       <tr>
@@ -57,8 +65,7 @@
         <td>{{ i["weight"] }}</td>
       </tr>
       {% endfor %}
-
-  </table>
+    </table>
 
   </div>
 

--- a/api/ooniapi/templates/debug_prio.html
+++ b/api/ooniapi/templates/debug_prio.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>OONI API</title>
+
+  {% block head_meta %}
+    <meta charset="UTF-8">
+  {% endblock %}
+
+  {% block head_css %}
+    <link href="/static/css/master.css" rel="stylesheet" />
+  {% endblock %}
+
+  {% block head %}
+  {% endblock %}
+
+  {% block head_js %}
+  {% endblock %}
+
+  <script src="https://www.kryogenix.org/code/browser/sorttable/sorttable.js"></script>
+
+</head>
+<body>
+{% block body %}
+
+  {% block navbar %}
+  {% endblock %}
+
+  {% block uncontained %}
+  {% endblock %}
+
+  <div class="container">
+
+    {% block content_fluid %}
+    {% endblock %}
+
+<form>
+  <label>CC</label> <input type="text" name="probe_cc"> <br>
+    <input type="submit" value="Submit">
+</form>
+
+    <table class="sortable">
+      <tr>
+        <th>url</th>
+        <th>category_code</th>
+        <th>msmt_cnt</th>
+        <th>priority</th>
+        <th>weight</th>
+      </tr>
+
+      {% for i in test_items %}
+      <tr class="item">
+        <td>{{ i["url"] }}</td>
+        <td>{{ i["category_code"] }}</td>
+        <td>{{ i["msmt_cnt"] }}</td>
+        <td>{{ i["priority"] }}</td>
+        <td>{{ i["weight"] }}</td>
+      </tr>
+      {% endfor %}
+
+  </table>
+
+  </div>
+
+  {% block footer %}
+    {% include 'footer.html' %}
+  {% endblock %}
+
+  {% block tail_js %}
+  {% endblock %}
+
+{% endblock %}
+</body>
+</html>
+


### PR DESCRIPTION
Implements https://github.com/ooni/backend/issues/739
The existing /api/_/debug_prioritization path returns JSON. This PR adds support for generating an HTML table that can be visualized in the browser to see what is in the test list.