### PR TITLE
fix(core.py): relax riseupvpn scoring logic

### DIFF
--- a/api/tests/integ/test_aggregation.py
+++ b/api/tests/integ/test_aggregation.py
@@ -301,12 +301,12 @@ def test_aggregation_x_axis_only_hour(client, log):
         "dimension_count": 1,
         "result": [
             {
-                "anomaly_count": 688,
+                "anomaly_count": 687,
                 "confirmed_count": 42,
                 "failure_count": 721,
                 "measurement_count": 9990,
                 "measurement_start_day": "2021-07-09T00:00:00Z",
-                "ok_count": 8539,
+                "ok_count": 8540,
             },
             {
                 "anomaly_count": 0,

--- a/fastpath/debian/changelog
+++ b/fastpath/debian/changelog
@@ -1,3 +1,9 @@
+fastpath (0.81) unstable; urgency=medium
+
+  * Relax riseupvpn scoring (see https://github.com/ooni/backend/issues/745)
+
+ -- Simone Basso <simone@openobservatory.org>  Wed, 17 Oct 2023 16:10:00 +0200
+
 fastpath (0.80) unstable; urgency=medium
 
   * Buffer writes to DB

--- a/fastpath/fastpath/core.py
+++ b/fastpath/fastpath/core.py
@@ -1432,23 +1432,9 @@ def score_riseupvpn(msm: dict) -> dict:
     """Calculate measurement scoring for RiseUp VPN
     Returns a scores dict
     """
-    # https://github.com/ooni/backend/issues/541
-    scores = init_scores()
-    tk = g_or(msm, "test_keys", {})
-    tstatus = tk.get("transport_status") or {}
-    obfs4 = tstatus.get("obfs4")
-    openvpn = tstatus.get("openvpn")
-    anomaly = (
-        tk.get("api_status") == "blocked"
-        or tk.get("ca_cert_status") is False
-        or obfs4 == "blocked"
-        or openvpn == "blocked"
-    )
-    if anomaly:
-        scores["blocking_general"] = 1.0
-
-    scores["extra"] = dict(test_runtime=msm.get("test_runtime"))
-    return scores
+    # originally, there was scoring: https://github.com/ooni/backend/issues/541
+    # on 2023-10-17, we disabled scoring: https://github.com/ooni/backend/issues/745
+    return {}
 
 
 def score_openvpn(msm: dict) -> dict:

--- a/fastpath/fastpath/tests/test_functional.py
+++ b/fastpath/fastpath/tests/test_functional.py
@@ -1217,14 +1217,7 @@ def test_score_torsf():
 def test_score_riseupvpn():
     for can_fn, msm in minicans("riseupvpn", date(2021, 10, 15), date(2021, 10, 16), 1):
         scores = fp.score_measurement(msm)
-        assert scores == {
-            "blocking_general": 0.0,
-            "blocking_global": 0.0,
-            "blocking_country": 0.0,
-            "blocking_isp": 0.0,
-            "blocking_local": 0.0,
-            "extra": {"test_runtime": 3.8260852},
-        }
+        assert scores == {}
         assert msm["report_id"] == "20211015T005140Z_riseupvpn_AR_7303_n1_gc8so3BXiS9thxBJ"
         return
 

--- a/fastpath/fastpath/tests/test_unit.py
+++ b/fastpath/fastpath/tests/test_unit.py
@@ -505,14 +505,7 @@ def test_score_tor_list():
 def test_score_riseupvpn():
     msm = loadj("riseupvpn")
     scores = fp.score_measurement(msm)
-    assert scores == {
-        "blocking_general": 1.0,
-        "blocking_global": 0.0,
-        "blocking_country": 0.0,
-        "blocking_isp": 0.0,
-        "blocking_local": 0.0,
-        "extra": {"test_runtime": 1.076507343},
-    }
+    assert scores == {}
 
 
 # # test_name: meek_fronted_requests_test


### PR DESCRIPTION
This diff relaxes the riseupvpn scoring logic because we have
determined in https://github.com/ooni/probe-cli/pull/1125#issuecomment-1666364558
that we want this experiment to just collect data useful to riseup.

Closes https://github.com/ooni/backend/issues/745.