### PR TITLE
chore(check-in): force vanilla_tor to be enabled

### DIFF
--- a/api/debian/changelog
+++ b/api/debian/changelog
@@ -1,3 +1,9 @@
+ooni-api (1.0.79) unstable; urgency=medium
+
+  * Mark vanilla_tor as disabled by default https://github.com/ooni/probe-cli/pull/1374
+
+ -- Simone Basso <simone@openobservatory.org>  Thu, 19 Oct 2023 12:35:00 +0200
+
 ooni-api (1.0.78) unstable; urgency=medium
 
   * Return email address on login

--- a/api/ooniapi/probe_services.py
+++ b/api/ooniapi/probe_services.py
@@ -264,7 +264,7 @@ def check_in() -> Response:
         test_items = []
 
     metrics.gauge("check-in-test-list-count", len(test_items))
-    conf: Dict[str, Any] = dict(features={"torsf_enabled": True})
+    conf: Dict[str, Any] = dict(features={"torsf_enabled": True, "vanilla_tor_enabled": True})
 
     # set webconnectivity_0.5 feature flag for some probes
     octect = extract_probe_ipaddr_octect(1, 0)


### PR DESCRIPTION
This is the counterpart of https://github.com/ooni/probe-cli/pull/1374.

Reference issues: https://github.com/ooni/probe/issues/2553, https://github.com/ooni/backend/issues/742.