### PR TITLE
Temporarily disable 0.5 since it's not collecting network_events

### DIFF
--- a/api/debian/changelog
+++ b/api/debian/changelog
@@ -1,6 +1,6 @@
 ooni-api (1.0.89) unstable; urgency=medium
 
-  * Disable wc 0.5
+  * Disable web_connectivity 0.5 feature flag
 
  -- Arturo <arturo@ooni.org>  Wed, 21 Feb 2024 16:25:18 +0100
 

--- a/api/debian/changelog
+++ b/api/debian/changelog
@@ -1,3 +1,9 @@
+ooni-api (1.0.89) unstable; urgency=medium
+
+  * Disable wc 0.5
+
+ -- Arturo <arturo@ooni.org>  Wed, 21 Feb 2024 16:25:18 +0100
+
 ooni-api (1.0.88) unstable; urgency=medium
 
   * Add more logging

--- a/api/ooniapi/probe_services.py
+++ b/api/ooniapi/probe_services.py
@@ -276,9 +276,12 @@ def check_in() -> Response:
     )
 
     # set webconnectivity_0.5 feature flag for some probes
-    octect = extract_probe_ipaddr_octect(1, 0)
-    if octect in (34, 239):
-        conf["features"]["webconnectivity_0.5"] = True
+    # Temporarily disabled while we work towards deploying this in prod:
+    # https://github.com/ooni/probe/issues/2674
+    #
+    #octect = extract_probe_ipaddr_octect(1, 0)
+    #if octect in (34, 239):
+    #    conf["features"]["webconnectivity_0.5"] = True
 
     conf["test_helpers"] = generate_test_helpers_conf()
 


### PR DESCRIPTION
While we work towards releasing a probe-engine release that addresses: https://github.com/ooni/probe/issues/2674, we should disable 0.5 for all users.