### PR TITLE
Fix typing of oonirun_link_id

### DIFF
--- a/.github/workflows/test_dataapi.yml
+++ b/.github/workflows/test_dataapi.yml
@@ -2,7 +2,7 @@ name: Tests
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
       - "*"

--- a/api/fastapi/oonidataapi/routers/oonirun.py
+++ b/api/fastapi/oonidataapi/routers/oonirun.py
@@ -106,7 +106,7 @@ class OONIRunLinkBase(BaseModel):
 
 
 class OONIRunLink(OONIRunLinkBase):
-    oonirun_link_id: int
+    oonirun_link_id: str
     date_created: datetime = Field(
         description="time when the ooni run link was created"
     )
@@ -139,10 +139,10 @@ class OONIRunLinkCreateEdit(OONIRunLinkBase):
     pass
 
 
-def generate_random_intuid() -> int:
+def generate_link_id() -> str:
     collector_id = 0
     randint = int.from_bytes(urandom(4), byteorder)
-    return randint * 100 + collector_id
+    return str(randint * 100 + collector_id)
 
 
 @router.post(
@@ -164,7 +164,7 @@ def create_oonirun_link(
     now = datetime.now(timezone.utc).replace(microsecond=0)
 
     oonirun_link = models.OONIRunLink(
-        oonirun_link_id=generate_random_intuid(),
+        oonirun_link_id=generate_link_id(),
         creator_account_id=account_id,
         name=create_request.name,
         name_intl=create_request.name_intl,

--- a/api/fastapi/oonidataapi/tests/test_oonirun.py
+++ b/api/fastapi/oonidataapi/tests/test_oonirun.py
@@ -81,7 +81,7 @@ def test_oonirun_not_found(client, client_with_user_role, client_with_admin_role
     assert r.status_code == 200, r.json()
     j = r.json()
     assert str(j["oonirun_link_id"]).endswith("00")
-    oonirun_link_id = int(r.json()["oonirun_link_id"])
+    oonirun_link_id = r.json()["oonirun_link_id"]
 
     j["expiration_date"] = (
         datetime.now(timezone.utc) + timedelta(minutes=-1)
@@ -115,14 +115,14 @@ def test_oonirun_full_workflow(client, client_with_user_role, client_with_admin_
     r = client_with_user_role.post("/api/v2/oonirun", json=z)
     assert r.status_code == 200, r.json()
     assert str(r.json()["oonirun_link_id"]).endswith("00")
-    oonirun_link_id = int(r.json()["oonirun_link_id"])
+    oonirun_link_id = r.json()["oonirun_link_id"]
 
     z["name"] = "second descriptor in English"
     z["name_intl"]["it"] = "second integ-test nome in italiano"
     r = client_with_user_role.post("/api/v2/oonirun", json=z)
     assert r.status_code == 200, r.json()
     assert str(r.json()["oonirun_link_id"]).endswith("00")
-    oonirun_link_id = int(r.json()["oonirun_link_id"])
+    oonirun_link_id = r.json()["oonirun_link_id"]
 
     r = client_with_user_role.get(f"/api/v2/oonirun/{oonirun_link_id}")
     assert r.status_code == 200, r.json()
@@ -353,7 +353,7 @@ def test_oonirun_expiration(client, client_with_user_role):
     r = client_with_user_role.post("/api/v2/oonirun", json=z)
     assert r.status_code == 200, r.json()
     assert str(r.json()["oonirun_link_id"]).endswith("00")
-    oonirun_link_id = int(r.json()["oonirun_link_id"])
+    oonirun_link_id = r.json()["oonirun_link_id"]
 
     ## Fetch anonymously and check it's not expired
     r = client.get(f"/api/v2/oonirun/{oonirun_link_id}")
@@ -422,7 +422,7 @@ def test_oonirun_revisions(client, client_with_user_role):
     r = client_with_user_role.post("/api/v2/oonirun", json=z)
     assert r.status_code == 200, r.json()
     j = r.json()
-    oonirun_link_id_one = int(j["oonirun_link_id"])
+    oonirun_link_id_one = j["oonirun_link_id"]
 
     ## Create two new revisions
     j["nettests"][0]["inputs"].append("https://foo.net/")
@@ -439,7 +439,7 @@ def test_oonirun_revisions(client, client_with_user_role):
     r = client_with_user_role.post("/api/v2/oonirun", json=z)
     assert r.status_code == 200, r.json()
     j = r.json()
-    oonirun_link_id_two = int(j["oonirun_link_id"])
+    oonirun_link_id_two = j["oonirun_link_id"]
 
     ## Create new revision
     j["nettests"][0]["inputs"].append("https://foo.net/")


### PR DESCRIPTION
The OONI Run link ID needs to be consistently be treated as a string.