### PR TITLE
fix(probe_services): disable torsf

### DIFF
--- a/api/ooniapi/probe_services.py
+++ b/api/ooniapi/probe_services.py
@@ -272,7 +272,12 @@ def check_in() -> Response:
 
     metrics.gauge("check-in-test-list-count", len(test_items))
     conf: Dict[str, Any] = dict(
-        features={"torsf_enabled": True, "vanilla_tor_enabled": True}
+        features={
+            # TODO(https://github.com/ooni/probe-cli/pull/1522): we disable torsf until we have
+            # addressed the issue with the fast.ly based rendezvous method being broken
+            "torsf_enabled": False,
+            "vanilla_tor_enabled": True,
+        }
     )
 
     # set webconnectivity_0.5 feature flag for some probes


### PR DESCRIPTION
This diff uses richer input to disable the torsf experiment. This works under the assumption that probes periodically call check-in and refresh feature flags, which should be true for the probes maintained by the OONI team.

Mitigation for https://github.com/ooni/probe/issues/2692