### PR TITLE
chore(Makefile): Use in-built compose for docker

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -17,7 +17,7 @@ RUN ./ooni_download_geoip.py
 
 RUN rm -rf /scripts
 
-# The API codebase is mounted under /app by docker-compose
+# The API codebase is mounted under /app using `docker compose` command
 
 # Set our work directory to our app directory
 WORKDIR /app/

--- a/api/Makefile
+++ b/api/Makefile
@@ -23,12 +23,12 @@ TESTARGS ?= \
 #tests/integ/test_integration_auth.py
 
 .state/docker-build: Dockerfile
-	docker-compose build --force-rm api
+	docker compose build --force-rm api
 	mkdir -p .state
 	touch .state/docker-build
 
 serve: .state/docker-build
-	docker-compose up --remove-orphans
+	docker compose up --remove-orphans
 
 build:
 	@$(MAKE) .state/docker-build
@@ -37,12 +37,12 @@ initdb:
 	# Setup database fixtures
 	# Fetch fingerprints from github
 	# run fastpath to populate the DB
-	docker-compose run --rm api python3 -m pytest --setup-only --create-db -s -x tests/unit/test_unit.py
+	docker compose run --rm api python3 -m pytest --setup-only --create-db -s -x tests/unit/test_unit.py
 
 tests: .state/docker-build
-	docker-compose run --rm api python3 -m pytest $(T) $(TESTARGS)
+	docker compose run --rm api python3 -m pytest $(T) $(TESTARGS)
 
 run-local:
-	docker-compose run --service-ports --rm api
+	docker compose run --service-ports --rm api
 
 .PHONY: build initdb tests serve run-local

--- a/api/README.md
+++ b/api/README.md
@@ -6,8 +6,7 @@ File bugs with the API inside of: https://github.com/ooni/backend/issues/new
 
 ## Local development
 
-You can run the OONI API locally in a development environment using `docker`
-and `docker-compose`. Follow the instructions below to set it up.
+You can run the OONI API locally in a development environment using `docker`. Follow the instructions below to set it up.
 
 ### Quickstart
 

--- a/api/tools/check_apispec_changes
+++ b/api/tools/check_apispec_changes
@@ -1,5 +1,5 @@
 #!/bin/bash
-docker-compose run --rm api python3 ooniapi/app.py
+docker compose run --rm api python3 ooniapi/app.py
 if diff apispec.json docs/apispec.json; then
   echo docs/apispec.json is up to date
 else


### PR DESCRIPTION
`docker-compose` is now an integral part of docker an no longer has an independent binary.

The new way to use `docker-compose` is via `docker compose`, `docker-compose` still works but users who want to keep using the utility can set aliases.

This would prevent this script from forcing contributors to install legacy tooling without need.