### PR TITLE
fix: smoketest permissions

### DIFF
--- a/ooniapi/services/oonifindings/Makefile
+++ b/ooniapi/services/oonifindings/Makefile
@@ -38,6 +38,7 @@ docker-push:
 	docker push ${IMAGE_NAME}:${ENV_LABEL}
 
 docker-smoketest:
+	chmod +x ./scripts/docker-smoketest.sh
 	./scripts/docker-smoketest.sh ${IMAGE_NAME}:${BUILD_LABEL}
 
 imagedefinitions.json:


### PR DESCRIPTION
This elevated the permissions of the `docker-smoketest.sh` to be executable. This was observed when running AWS `CodeBuild` while deploying the service: 

```
[Container] 2024/08/10 12:52:54.850853 Running command make docker-smoketest
--
475 | make: hatch: No such file or directory
476 | ./scripts/docker-smoketest.sh ooni/api-oonifindings:20240810-53a3bf7d
477 | make: ./scripts/docker-smoketest.sh: Permission denied
478 | make: *** [Makefile:41: docker-smoketest] Error 127
```