### PR TITLE
fix: enable health endpoint

### DIFF
--- a/ooniapi/services/oonifindings/src/oonifindings/main.py
+++ b/ooniapi/services/oonifindings/src/oonifindings/main.py
@@ -70,24 +70,24 @@ async def health(
 ):
     errors = []
 
-    #try:
-    #    db.query(models.OONIFinding).limit(1).all()
-    #except Exception as exc:
-    #    log.error(exc)
-    #    errors.append("db_error")
+    try:
+       db.query(models.OONIFinding).limit(1).all()
+    except Exception as exc:
+       log.error(exc)
+       errors.append("db_error")
 
-    #if settings.jwt_encryption_key == "CHANGEME":
-    #    err = "bad_jwt_secret"
-    #    log.error(err)
-    #    errors.append(err)
+    if settings.jwt_encryption_key == "CHANGEME":
+       err = "bad_jwt_secret"
+       log.error(err)
+       errors.append(err)
 
-    #if settings.prometheus_metrics_password == "CHANGEME":
-    #    err = "bad_prometheus_password"
-    #    log.error(err)
-    #    errors.append(err)
+    if settings.prometheus_metrics_password == "CHANGEME":
+       err = "bad_prometheus_password"
+       log.error(err)
+       errors.append(err)
 
-    #if len(errors) > 0:
-    #    raise HTTPException(status_code=400, detail="health check failed")
+    if len(errors) > 0:
+       raise HTTPException(status_code=400, detail="health check failed")
 
     status = "ok"
 


### PR DESCRIPTION
As mentioned in #869, we wanted to disable the `/health` checkpoint for an initial deployment. We can now re-instate the endpoint and the codepipeline should pass through