### PR TITLE
fix(oonifindings): set default query parameter value

### DIFF
--- a/ooniapi/services/oonifindings/src/oonifindings/routers/v1.py
+++ b/ooniapi/services/oonifindings/src/oonifindings/routers/v1.py
@@ -137,11 +137,11 @@ class OONIFindingIncidents(BaseModel):
     response_model=OONIFindingIncidents
 )
 def list_oonifindings(
+    response: Response,
     only_mine: Annotated[
         bool,
         Query(description="show only owned items")
-    ],
-    response: Response,
+    ] = False,
     authorization: str = Header("authorization"),
     db=Depends(get_postgresql_session),
     settings=Depends(get_settings),


### PR DESCRIPTION
It turns out that the the `only_mine` parameter in the legacy api was optional for the `/api/v1/search` endpoint. This diff ensures that we set this default query parameter value to `False`.