### PR TITLE
Fix setting X-Forwarded-For inside of ALB setup

### DIFF
--- a/ooniapi/services/reverseproxy/templates/backend-proxy.conf.template
+++ b/ooniapi/services/reverseproxy/templates/backend-proxy.conf.template
@@ -3,6 +3,7 @@ gzip_proxied any;
 gzip_types text/plain application/json;
 gzip_min_length 1000;
 
+
 server {
     listen 8080;
     location /stub_status {
@@ -11,6 +12,8 @@ server {
 }
 
 server {
+    real_ip_header X-Forwarded-For;
+
     listen 80;
 
     server_name _;
@@ -26,7 +29,7 @@ server {
         proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Real-IP $http_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
         proxy_cache_bypass $http_upgrade;
     }
 }


### PR DESCRIPTION
If somebody is setting X-Forwarded-For it will lead to X-Real-Ip containing a list instead of a fixed IP.

We can instead trust the last item in the X-Forwarded-For list since this comes from ALB as we are running it in append mode (see: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html)

We should make sure we don't change the mode to something other than `append` otherwise we expose to ourselves to clients overriding X-Real-Ip.

Fixes: https://github.com/ooni/backend/issues/901