### PR TITLE
Add support for passing a list to filters in list_measurements

### DIFF
--- a/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/v1/measurements.py
+++ b/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/v1/measurements.py
@@ -851,7 +851,7 @@ async def list_measurements(
                     probe_asn="AS{}".format(row["probe_asn"]),
                     test_name=row["test_name"],
                     measurement_start_time=row["measurement_start_time"],
-                    input_=row["input"],
+                    input=row["input"],
                     anomaly=row["anomaly"] == "t",  # TODO: This is wrong
                     confirmed=row["confirmed"] == "t",
                     failure=row["msm_failure"] == "t",

--- a/ooniapi/services/oonimeasurements/tests/test_measurements.py
+++ b/ooniapi/services/oonimeasurements/tests/test_measurements.py
@@ -93,5 +93,6 @@ def test_list_measurements_with_multiple_values_to_filters_not_in_the_result(cli
     json = response.json()
     assert isinstance(json["results"], list), json
     assert len(json["results"]) > 0
+    domain_list = domainCollection.split(", ")
     for result in json["results"]:
-        assert any(domain in result["input"] for domain in domainCollection), result
+        assert any(domain in result["input"] for domain in domain_list), result

--- a/ooniapi/services/oonimeasurements/tests/test_measurements.py
+++ b/ooniapi/services/oonimeasurements/tests/test_measurements.py
@@ -1,0 +1,91 @@
+import pytest
+
+
+route = "api/v1/measurements"
+
+
+def test_list_measurements(client):
+    response = client.get(route)
+    json = response.json()
+
+    assert isinstance(json["results"], list), json
+    assert len(json["results"]) == 100
+
+
+def test_list_measurements_with_since_and_until(client):
+    params = {
+        "since": "2024-01-01",
+        "until": "2024-01-02",
+    }
+
+    response = client.get(route, params=params)
+    json = response.json()
+
+    assert isinstance(json["results"], list), json
+    assert len(json["results"]) == 100
+
+
+@pytest.mark.parametrize(
+    "filter_param, filter_value",
+    [
+        ("test_name", "web_connectivity"),
+        ("probe_cc", "IT"),
+        ("probe_asn", "AS30722"),
+    ]
+)
+def test_list_measurements_with_one_value_to_filters(client, filter_param, filter_value):
+    params = {}
+    params[filter_param] = filter_value
+
+    response = client.get(route, params=params)
+
+    json = response.json()
+    assert isinstance(json["results"], list), json
+    assert len(json["results"]) > 0
+    for result in json["results"]:
+        assert result[filter_param] == filter_value, result
+
+
+def test_list_measurements_with_one_value_to_filters_not_in_the_result(client):
+    params = {
+        "domain": "cloudflare-dns.com",
+    }
+
+    response = client.get(route, params=params)
+
+    json = response.json()
+    assert isinstance(json["results"], list), json
+    assert len(json["results"]) > 0
+
+
+@pytest.mark.parametrize(
+    "filter_param, filter_value",
+    [
+        ("test_name", "web_connectivity,dnscheck,stunreachability,tor"),
+        ("probe_cc", "IT,US,RU"),
+        ("probe_asn", "AS30722,3269,7738,55430"),
+    ]
+)
+def test_list_measurements_with_multiple_values_to_filters(client, filter_param, filter_value):
+    params = {}
+    params[filter_param] = filter_value
+
+    response = client.get(route, params=params)
+
+    json = response.json()
+    assert isinstance(json["results"], list), json
+    assert len(json["results"]) > 0
+    for result in json["results"]:
+        assert result[filter_param] in filter_value, result
+
+
+def test_list_measurements_with_multiple_values_to_filters_not_in_the_result(client):
+    params = {
+        "domain": "cloudflare-dns.com, adblock.doh.mullvad.net, 1.1.1.1",
+    }
+
+    response = client.get(route, params=params)
+
+    json = response.json()
+    assert isinstance(json["results"], list), json
+    assert len(json["results"]) > 0

--- a/ooniapi/services/oonimeasurements/tests/test_measurements.py
+++ b/ooniapi/services/oonimeasurements/tests/test_measurements.py
@@ -46,9 +46,10 @@ def test_list_measurements_with_one_value_to_filters(client, filter_param, filte
         assert result[filter_param] == filter_value, result
 
 
-def test_list_measurements_with_one_value_to_filters_not_in_the_result(client):
+def test_list_measurements_with_one_value_to_filters_not_present_in_the_result(client):
+    domain = "cloudflare-dns.com"
     params = {
-        "domain": "cloudflare-dns.com",
+        "domain": domain,
     }
 
     response = client.get(route, params=params)
@@ -56,6 +57,8 @@ def test_list_measurements_with_one_value_to_filters_not_in_the_result(client):
     json = response.json()
     assert isinstance(json["results"], list), json
     assert len(json["results"]) > 0
+    for result in json["results"]:
+        assert domain in result["input"], result
 
 
 @pytest.mark.parametrize(
@@ -80,8 +83,9 @@ def test_list_measurements_with_multiple_values_to_filters(client, filter_param,
 
 
 def test_list_measurements_with_multiple_values_to_filters_not_in_the_result(client):
+    domainCollection = "cloudflare-dns.com, adblock.doh.mullvad.net, 1.1.1.1"
     params = {
-        "domain": "cloudflare-dns.com, adblock.doh.mullvad.net, 1.1.1.1",
+        "domain": domainCollection
     }
 
     response = client.get(route, params=params)
@@ -89,3 +93,5 @@ def test_list_measurements_with_multiple_values_to_filters_not_in_the_result(cli
     json = response.json()
     assert isinstance(json["results"], list), json
     assert len(json["results"]) > 0
+    for result in json["results"]:
+        assert any(domain in result["input"] for domain in domainCollection), result


### PR DESCRIPTION
This PR is about the issue https://github.com/ooni/backend/issues/795

Steps:
- Changes to accept the following filters as lists (domain, test_name, probe_cc, probe_asn)

Notes:
- Fix a problem with scores type.
- Fix a problem with the input variable.
