### PR TITLE
Log probe update metadata

### DIFF
--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -193,8 +193,9 @@ def probe_update_post(probe_update: ProbeUpdate) -> ProbeUpdateResponse:
 
     # Info doesn't allows list, if we have a list we have to convert it
     # to string
-    if probe_update_dict["supported_tests"] is not None:
+    if probe_update_dict.get("supported_tests") is not None:
         tests = probe_update_dict["supported_tests"]
+        tests.sort()
         tests_str = ";".join(tests)
         probe_update_dict["supported_tests"] = tests_str
 

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime, timezone, timedelta
 import time
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Response
 
@@ -131,7 +131,28 @@ def probe_register_post(
 
 
 class ProbeUpdate(BaseModel):
-    pass
+    """
+    The original format of this comes from: 
+    https://github.com/ooni/orchestra/blob/master/registry/registry/handler/registry.go#L25
+    """
+    probe_cc : Optional[str] = None
+    probe_asn : Optional[str] = None
+    platform : Optional[str]  = None
+
+    software_name : Optional[str]  = None
+    software_version : Optional[str]  = None
+    supported_tests : Optional[List[str]] = None
+
+    network_type : Optional[str] = None
+    available_bandwidth : Optional[str] = None
+    language : Optional[str] = None
+
+    token : Optional[str] = None
+
+    probe_family : Optional[str] = None
+    probe_id : Optional[str] = None
+
+    password : Optional[str] = None
 
 
 class ProbeUpdateResponse(BaseModel):

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -51,9 +51,6 @@ def probe_login_post(
         raise HTTPException(status_code=401, detail="Missing credentials")
 
     token = probe_login.username
-    # TODO: We have to find a way to explicitly log metrics with prometheus.
-    # We're currently using the instrumentator default metrics, like http response counts
-    # Maybe using the same exporter as the instrumentator?
 
     try:
         dec = decode_jwt(token, audience="probe_login", key=settings.jwt_encryption_key)

--- a/ooniapi/services/ooniprobe/tests/test_probe_auth.py
+++ b/ooniapi/services/ooniprobe/tests/test_probe_auth.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Any
 from ooniprobe.common import auth
 from fastapi.testclient import TestClient
 
@@ -58,14 +58,14 @@ def test_update(client: TestClient, jwt_encryption_key):
     assert json["status"] == "ok"
 
 
-def _get_update_data() -> Dict[str, str]:
+def _get_update_data() -> Dict[str, Any]:
     return {
         "probe_cc": "IT",
         "probe_asn": "AS1234",
         "platform": "android",
         "software_name": "ooni-testing",
         "software_version": "0.0.1",
-        "supported_tests": "web_connectivity",
+        "supported_tests": ["web_connectivity"],
         "network_type": "wifi",
         "available_bandwidth": "100",
         "language": "en",


### PR DESCRIPTION
This PR adds Prometheus metrics to log probe update metadata that is usually ignored by the new update endpoint. 

The goal is to eventually use this data for anomaly detection in measurement update

This solves #925 