### PR TITLE
Fixed oonimeasurements tests

### DIFF
--- a/ooniapi/services/oonimeasurements/tests/conftest.py
+++ b/ooniapi/services/oonimeasurements/tests/conftest.py
@@ -48,7 +48,7 @@ def is_clickhouse_running(url):
 @pytest.fixture(scope="session")
 def clickhouse_server(maybe_download_fixtures, docker_ip, docker_services):
     port = docker_services.port_for("clickhouse", 9000)
-    url = "clickhouse://{}:{}".format(docker_ip, port)
+    url = "clickhouse://test:test@{}:{}".format(docker_ip, port)
     docker_services.wait_until_responsive(
         timeout=30.0, pause=0.1, check=lambda: is_clickhouse_running(url)
     )

--- a/ooniapi/services/oonimeasurements/tests/docker-compose.yml
+++ b/ooniapi/services/oonimeasurements/tests/docker-compose.yml
@@ -7,3 +7,7 @@ services:
     volumes:
         - ./fixtures:/fixtures
         - ./fixtures/initdb:/docker-entrypoint-initdb.d/
+
+    environment:
+      CLICKHOUSE_PASSWORD: test
+      CLICKHOUSE_USER: test


### PR DESCRIPTION
The tests for `oonimeasurements` were hanging because the docker compose that spins up the clickhouse database was not properly configured. It didn't provide a default password and the clickhouse fixture wasn't specifying a password, so it could never connect to docker

closes #944 