### PR TITLE
Fix test legacy API endpoint

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -23,12 +23,12 @@ TESTARGS ?= \
 #tests/integ/test_integration_auth.py
 
 .state/docker-build: Dockerfile
-	docker-compose build --force-rm api
+	docker compose build --force-rm api
 	mkdir -p .state
 	touch .state/docker-build
 
 serve: .state/docker-build
-	docker-compose up --remove-orphans
+	docker compose up --remove-orphans
 
 build:
 	@$(MAKE) .state/docker-build
@@ -37,12 +37,12 @@ initdb:
 	# Setup database fixtures
 	# Fetch fingerprints from github
 	# run fastpath to populate the DB
-	docker-compose run --rm api python3 -m pytest --setup-only --create-db -s -x tests/unit/test_unit.py
+	docker compose run --rm api python3 -m pytest --setup-only --create-db -s -x tests/unit/test_unit.py
 
 tests: .state/docker-build
-	docker-compose run --rm api python3 -m pytest $(T) $(TESTARGS)
+	docker compose run --rm api python3 -m pytest $(T) $(TESTARGS)
 
 run-local:
-	docker-compose run --service-ports --rm api
+	docker compose run --service-ports --rm api
 
 .PHONY: build initdb tests serve run-local

--- a/api/build_runner.sh
+++ b/api/build_runner.sh
@@ -18,8 +18,10 @@ locale-gen en_US.UTF-8
 # Set up OONI archive
 echo 'deb http://deb-ci.ooni.org unstable main' \
   > /etc/apt/sources.list.d/ooni.list
-apt-key adv --keyserver hkps://keys.openpgp.org \
-  --recv-keys "B5A08F01796E7F521861B449372D1FF271F2DD50"
+
+mkdir -p /etc/apt/keyrings
+mkdir -p /root/.gnupg
+gpg --no-default-keyring --keyserver hkp://keyserver.ubuntu.com --keyring /etc/apt/keyrings/ooni-apt-keyring.gpg --recv-keys 'B5A08F01796E7F521861B449372D1FF271F2DD50'
 
 apt-get update
 # Keep this in sync with debian/control

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 
 services:
   clickhouse:


### PR DESCRIPTION
Fix broken tests due to old docker configuration and deprecated keyring configuration

Note that some tests are still failing due to what seems to be correctness errors, but at the least the setup is no longer broken

closes #949  