### PR TITLE
fix: disable openvpn from check-in

### DIFF
--- a/api/debian/changelog
+++ b/api/debian/changelog
@@ -1,3 +1,9 @@
+ooni-api (1.0.96) unstable; urgency=medium
+
+  * disable openvpn from check-in
+
+ -- Mehul <mehul@ooni.org>  Tue, 1 Apr 2025 10:41:29 +0530
+
 ooni-api (1.0.95) unstable; urgency=medium
 
   * return only 6,5 test helpers

--- a/api/ooniapi/probe_services.py
+++ b/api/ooniapi/probe_services.py
@@ -280,6 +280,7 @@ def check_in() -> Response:
             # addressed the issue with the fast.ly based rendezvous method being broken
             "torsf_enabled": False,
             "vanilla_tor_enabled": True,
+            "openvpn_enabled": False,
         }
     )
 

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -376,6 +376,7 @@ def check_in(
             # addressed the issue with the fast.ly based rendezvous method being broken
             "torsf_enabled": False,
             "vanilla_tor_enabled": True,
+            "openvpn_enabled": False,
         }
     )
 


### PR DESCRIPTION
This disables the openvpn experiment from the check-in endpoint. This is a hotfix for https://github.com/ooni/devops/issues/228