### PR TITLE
Fix bad failure field

### DIFF
--- a/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/v1/measurements.py
+++ b/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/v1/measurements.py
@@ -294,7 +294,7 @@ def format_msmt_meta(msmt_meta: dict) -> MeasurementMeta:
         report_id=msmt_meta["report_id"],
         test_name=msmt_meta["test_name"],
         test_start_time=msmt_meta["test_start_time"],
-        probe_asn=msmt_meta["probe_asn"],
+        probe_asn=str(msmt_meta["probe_asn"]),
         probe_cc=msmt_meta["probe_cc"],
         scores=msmt_meta["scores"],
         anomaly=(msmt_meta["anomaly"] == "t"),

--- a/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/v1/measurements.py
+++ b/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/v1/measurements.py
@@ -299,7 +299,7 @@ def format_msmt_meta(msmt_meta: dict) -> MeasurementMeta:
         scores=msmt_meta["scores"],
         anomaly=(msmt_meta["anomaly"] == "t"),
         confirmed=(msmt_meta["confirmed"] == "t"),
-        failure=(msmt_meta["failure"] == "t"),
+        failure=(msmt_meta["msm_failure"] == "t"),
         category_code=msmt_meta.get("category_code", None),
     )
     return formatted_msmt_meta


### PR DESCRIPTION
Quick fix for validation errors for measurement meta:

- We were using `failure` instead of `msm_failure` to retrieve the failure field from the clickhouse query
- We were passing the ASN as int rather than a string, as expected by the `MeasurementMeta` model