### PR TITLE
Add limit to test query 

### DIFF
--- a/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/v1/measurements.py
+++ b/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/v1/measurements.py
@@ -294,7 +294,7 @@ def format_msmt_meta(msmt_meta: dict) -> MeasurementMeta:
         report_id=msmt_meta["report_id"],
         test_name=msmt_meta["test_name"],
         test_start_time=msmt_meta["test_start_time"],
-        probe_asn=msmt_meta["probe_asn"],
+        probe_asn=str(msmt_meta["probe_asn"]),
         probe_cc=msmt_meta["probe_cc"],
         scores=msmt_meta["scores"],
         anomaly=(msmt_meta["anomaly"] == "t"),

--- a/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/v1/measurements.py
+++ b/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/v1/measurements.py
@@ -299,7 +299,7 @@ def format_msmt_meta(msmt_meta: dict) -> MeasurementMeta:
         scores=msmt_meta["scores"],
         anomaly=(msmt_meta["anomaly"] == "t"),
         confirmed=(msmt_meta["confirmed"] == "t"),
-        failure=(msmt_meta["failure"] == "t"),
+        failure=(msmt_meta["msm_failure"] == "t"),
         category_code=msmt_meta.get("category_code", None),
     )
     return formatted_msmt_meta

--- a/ooniapi/services/oonimeasurements/tests/test_measurements.py
+++ b/ooniapi/services/oonimeasurements/tests/test_measurements.py
@@ -102,7 +102,7 @@ def test_list_measurements_with_multiple_values_to_filters_not_in_the_result(cli
 
 def test_failure_format(db):
     ch = Clickhouse.from_url(db)
-    msm = query_click_one_row(ch, "select * from fastpath where test_name = 'web_connectivity'", {}) or {}
+    msm = query_click_one_row(ch, "SELECT * FROM fastpath WHERE test_name = 'web_connectivity' LIMIT 1", {}) or {}
     uid = msm['measurement_uid']
 
     q = """


### PR DESCRIPTION
Add a `limit 1` to a testing query in oonimeasurements to optimize the test