### PR TITLE
Oonimsm fixes

### DIFF
--- a/fastpath/fastpath/core.py
+++ b/fastpath/fastpath/core.py
@@ -1622,6 +1622,7 @@ def write_measurement_to_disk(msm_tup) -> None:
         msm_tup: Measurement tuple as it comes from the work queue
     """
 
+    # msmt_uid is a unique id based on upload time, cc, testname and hash
     data, measurement, msmt_uid = msm_tup
     ts, cc, test_name, h = msmt_uid.split("_")
 
@@ -1632,15 +1633,9 @@ def write_measurement_to_disk(msm_tup) -> None:
     msmtdir = spooldir / "incoming" / dirname
     msmtdir.mkdir(parents=True, exist_ok=True)
 
-    h = sha512(data).hexdigest()[:16]
-    ts = now.strftime("%Y%m%d%H%M%S.%f")
-
     try: 
-        # msmt_uid is a unique id based on upload time, cc, testname and hash
-        msmt_uid = f"{ts}_{cc}_{test_name}_{h}"
         msmt_f_tmp = msmtdir / f"{msmt_uid}.post.tmp"
         msmt_f_tmp.write_bytes(data)
-
         msmt_f = msmtdir / f"{msmt_uid}.post"
         msmt_f_tmp.rename(msmt_f)
     except Exception as exc:

--- a/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/v1/measurements.py
+++ b/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/v1/measurements.py
@@ -152,7 +152,7 @@ def _fetch_measurement_body_from_hosts(
         return None
 
     for hostname in other_collectors:
-        url = urljoin(f"https://{hostname}/measurement_spool/", path)
+        url = urljoin(f"{hostname}/measurement_spool/", path)
         log.debug(f"Attempt to load {url}")
         try:
             r = urllib_pool.request("GET", url)


### PR DESCRIPTION
Small fixes to make the oonimeasurements and fastpath components integrate properly:

- Move the protocol specification to the `other_collectors` setting instead of enforcing it in oonimeasurements
- Fix an issue where the fastpath would rewrite the ID of the measurement when writing to disk, generating slightly different IDs to the ones in the DB and leading to 404 errors. This doesn't affect the monolith version, only the EC2 version. 

Related to https://github.com/ooni/devops/pull/262