### PR TITLE
Workaround for missing arrayElementOrNull function

### DIFF
--- a/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/data/aggregate_analysis.py
+++ b/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/data/aggregate_analysis.py
@@ -240,7 +240,7 @@ def format_aggregate_query(extra_cols: Dict[str, str], where: str):
     IF(
         likely_blocked_protocols IS NOT NULL AND length(likely_blocked_protocols) > 0,
         arrayElement(likely_blocked_protocols, 1),
-        NULL
+        ('none', 0.0)
     ) as blocked_max_protocol
 
     FROM (


### PR DESCRIPTION
This function was introduced only in clickhouse 24.10+