### PR TITLE
Fix bad raw_measurement response encoding

### DIFF
--- a/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/v1/measurements.py
+++ b/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/v1/measurements.py
@@ -402,9 +402,9 @@ async def get_raw_measurement(
             db, settings, msmt_meta.report_id, msmt_meta.measurement_uid
         )
     else:
-        body = {}
+        body = "{}"
 
-    response = JSONResponse(content=jsonable_encoder(body))
+    response = Response(content=body, media_type="application/json")
     setcacheresponse("1d", response)
     return response
 

--- a/ooniapi/services/oonimeasurements/tests/test_measurements.py
+++ b/ooniapi/services/oonimeasurements/tests/test_measurements.py
@@ -156,3 +156,28 @@ def test_raw_measurement_args_optional(client, monkeypatch, maybe_download_fixtu
 
     resp = client.get("/api/v1/raw_measurement", params={})
     assert resp.status_code == 400, resp.status_code
+
+def test_raw_measurement_returns_json(client, monkeypatch, maybe_download_fixtures):
+    """
+    Test that raw_measurements returns json instead of a string
+    """
+
+    def fake_get_bucket_url(bucket_name):
+        return f"file://{THIS_DIR}/fixtures/"
+
+    monkeypatch.setattr(measurements, "get_bucket_url", fake_get_bucket_url)
+
+    uid = "20250709075147.833477_US_webconnectivity_8f0e0b49950f2592"
+    resp = client.get("/api/v1/raw_measurement", params={"measurement_uid" : uid})
+    assert resp.status_code == 200, resp.status_code
+
+    j = resp.json()
+    assert isinstance(j, dict), type(j)
+
+    # When not found should return empty dict
+    uid = "20250709075147.833477_US_webconnectivity_baddbaddbaddbadd"
+    resp = client.get("/api/v1/raw_measurement", params={"measurement_uid" : uid})
+    assert resp.status_code == 200, resp.status_code
+
+    j = resp.json()
+    assert j == {}, j


### PR DESCRIPTION
the `/raw_measurement` endpoint in `oonimeasurements` is returning a string with a json instead of a json itself 

This happened because the measurement body is downloaded as a string (a json string), and it's converted into a json again by FastApi's `JSONResponse`:

Our code: 
https://github.com/ooni/backend/blob/b04cfe72ad28fb68602756bc9300ae225b35e1cc/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/v1/measurements.py#L407C1-L409C20

`JSONResponse`: 
https://github.com/encode/starlette/blob/cb8f84f5284dc301ca7a31eb732b9e140769dd48/starlette/responses.py#L192C4-L199C4

