### PR TITLE
Reduce oonimeasurement load

### DIFF
--- a/api/debian/changelog
+++ b/api/debian/changelog
@@ -1,3 +1,11 @@
+ooni-api (1.0.98) unstable; urgency=medium
+
+  * Cap measurements api limit to 100
+  * Validate ordering fields for measurements endpoint
+  * Remove `test_start_time` from measurement list endpoint
+
+ -- Luis Diaz <luis@openobservatory.org>  Wed, 10 Sep 2025 13:22:01 +0200
+
 ooni-api (1.0.97) unstable; urgency=medium
 
   * Add fix and test for priority calculation

--- a/api/debian/changelog
+++ b/api/debian/changelog
@@ -2,7 +2,7 @@ ooni-api (1.0.98) unstable; urgency=medium
 
   * Cap measurements api limit to 100
   * Validate ordering fields for measurements endpoint
-  * Remove `test_start_time` from measurement list endpoint
+  * Remove `test_start_time` ordering field from measurement list endpoint
 
  -- Luis Diaz <luis@openobservatory.org>  Wed, 10 Sep 2025 13:22:01 +0200
 

--- a/api/ooniapi/measurements.py
+++ b/api/ooniapi/measurements.py
@@ -772,7 +772,7 @@ def list_measurements() -> Response:
         "probe_asn",
         "test_name"
     ]
-    if order_by.lower() not in valid_order_fields:
+    if order_by and order_by.lower() not in valid_order_fields:
         raise BadRequest("Invalid field for ordering: " + order_by + 
                          ". Valid options: " + str(valid_order_fields))
 

--- a/api/ooniapi/measurements.py
+++ b/api/ooniapi/measurements.py
@@ -665,7 +665,6 @@ def list_measurements() -> Response:
         type: string
         description: 'By which key the results should be ordered by (default: `null`)'
         enum:
-          - test_start_time
           - measurement_start_time
           - input
           - probe_cc
@@ -760,6 +759,22 @@ def list_measurements() -> Response:
 
     if order.lower() not in ("asc", "desc"):
         raise BadRequest("Invalid order")
+
+    # Cap limit to the range 0 to 100
+    if limit > 100:
+        raise BadRequest("`limit` is only allowed up to 100")
+
+    # Validate order_by fields
+    valid_order_fields = [
+        "measurement_start_time",
+        "input",
+        "probe_cc",
+        "probe_asn",
+        "test_name"
+    ]
+    if order_by.lower() not in valid_order_fields:
+        raise BadRequest("Invalid field for ordering: " + order_by + 
+                         ". Valid options: " + str(valid_order_fields))
 
     # # Perform query
 

--- a/ooniapi/services/oonimeasurements/tests/test_measurements.py
+++ b/ooniapi/services/oonimeasurements/tests/test_measurements.py
@@ -181,3 +181,32 @@ def test_raw_measurement_returns_json(client, monkeypatch, maybe_download_fixtur
 
     j = resp.json()
     assert j == {}, j
+
+def test_measurements_order_by_test_start_time_forbidden(client):
+    """
+    Tests that the `test_start_time` is NOT a valid order by field in oonimeasurements
+    """
+
+    resp = client.get("/api/v1/measurements", params = {
+        "order_by":  "test_start_time"
+    })
+
+    assert resp.status_code != 200, f"Unexpected code: {resp.status_code}"
+
+def test_measurements_limit_hard_capped(client):
+    """
+    Tests that the `limit` field in oonimeasurements is hard capped to 100
+    """
+
+    valids = [50, 100]
+    for valid in valids:
+        resp = client.get("/api/v1/measurements", params = {
+            "limit": valid
+        })
+        assert resp.status_code == 200, f"Unexpected code: {resp.status_code}"
+
+    resp = client.get("/api/v1/measurements", params = {
+        "limit": 101
+    })
+    assert resp.status_code != 200, f"Unexpected code: {resp.status_code}"
+


### PR DESCRIPTION
This PR will: 
- Cap the page size of `/api/v1/measurements` endpoint to 100
- Remove the `test_start_time` ordering field from the API
- Those two changes are added to both the monolith and the ECS version 

Closes #996 