### PR TITLE
Use safe yaml loader instead of default

### DIFF
--- a/api/ooni_api_uploader.py
+++ b/api/ooni_api_uploader.py
@@ -120,7 +120,7 @@ def fill_jsonl(measurements: List[PP], jsonlf: PP) -> List[Dict]:
                 msm = post.get("content", {})
             elif fmt == "yaml":
                 try:
-                    msm = yaml.load(msm, Loader=yaml.CLoader)
+                    msm = yaml.safe_load(msm, Loader=yaml.CLoader)
                 except Exception:
                     pass
 


### PR DESCRIPTION
This PR will change the unsafe `yaml.load` in api uploader with `yaml.safe_load` 