### PR TITLE
Fix round_robin_web_test_helpers to return 4 items instead of 5

### DIFF
--- a/api/ooniapi/probe_services.py
+++ b/api/ooniapi/probe_services.py
@@ -527,11 +527,11 @@ def round_robin_web_test_helpers() -> List[Dict]:
     if q < 10:
         shift = 0
     else:
-        shift = q % 4 + 1
+        shift = q % 3 + 1
 
     out = []
-    for n in range(5):
-        n = (n + shift) % 5
+    for n in range(4):
+        n = (n + shift) % 4
         out.append({"address": f"https://{n}.th.ooni.org", "type": "https"})
 
     return out


### PR DESCRIPTION
Fixes #973

## Problem
The `round_robin_web_test_helpers` function was creating 5 test helpers (0-4) but the test expected only 4 items (0-3).

## Solution
Updated the function to create 4 test helpers with the correct distribution:
- 0.th.ooni.org: 10% of traffic
- 1.th, 2.th, 3.th: 30% each

## Changes
- Adjusted shift calculation: `q % 4 + 1` → `q % 3 + 1` 
- Changed loop: `range(5)` → `range(4)`
- Updated modulo: `% 5` → `% 4`

## Testing
- ✅ Verified `test_round_robin_web_test_helpers` passes locally