### PR TITLE
make GeoLookupResult as_name field Optional with default emtpy string

### DIFF
--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -593,7 +593,7 @@ def random_web_test_helpers(th_list: List[str]) -> List[Dict]:
 class GeoLookupResult(BaseModel):
     cc: str = Field(description="Country Code")
     asn: str = Field(description="Autonomous System Number (ASN)")
-    as_name: str = Field(description="Autonomous System Name")
+    as_name: Optional[str] = Field("", description="Autonomous System Name")
 
 
 class GeoLookupRequest(BaseModel):
@@ -623,6 +623,8 @@ async def geolookup(
         # call probe_geoip() and map the keys to the geolookup v1 API
         resp, _, _ = probe_geoip(ipaddr, probe_cc, asn, cc_reader, asn_reader)
         # it doesn't seem possible to have separate aliases for (de)serialization
+        if resp["probe_network_name"] == None:
+            resp["probe_network_name"] = ""
         geolookup_resp["geolocation"][ipaddr] = GeoLookupResult(cc=resp["probe_cc"],
             asn=resp["probe_asn"], as_name=resp["probe_network_name"])
 

--- a/ooniapi/services/ooniprobe/tests/integ/test_geolookup.py
+++ b/ooniapi/services/ooniprobe/tests/integ/test_geolookup.py
@@ -9,6 +9,11 @@ def fake_lookup_probe_network(ipaddr: str, asn_reader: ASNReaderDep) -> Tuple[st
 def fake_lookup_probe_cc(ipaddr: str, cc_reader: CCReaderDep) -> str:
     return "US"
 
+def missing_lookup_probe_network(ipaddr: str, asn_reader: ASNReaderDep):
+    return ("AS0", None)
+
+def missing_lookup_probe_cc(ipaddr: str, cc_reader: CCReaderDep) -> str:
+    return "ZZ"
 
 def test_geolookup(client, monkeypatch):
     monkeypatch.setattr(ps, "lookup_probe_network", fake_lookup_probe_network)
@@ -25,3 +30,19 @@ def test_geolookup(client, monkeypatch):
         assert g[ip]["cc"] == "US"
         assert g[ip]["asn"] == "AS4242"
         assert g[ip]["as_name"] == "Testing Networks"
+
+def test_missing_geolookup(client, monkeypatch):
+    monkeypatch.setattr(ps, "lookup_probe_network", missing_lookup_probe_network)
+    monkeypatch.setattr(ps, "lookup_probe_cc", missing_lookup_probe_cc)
+    j = dict(
+        addresses=["1.2.3.4", "127.0.0.1"]
+    )
+    c = client.post("/api/v1/geolookup", json=j).json()
+    assert "geolocation" in c
+    assert "v" in c
+    g = c["geolocation"]
+
+    for ip in j["addresses"]:
+        assert g[ip]["cc"] == "ZZ"
+        assert g[ip]["asn"] == "AS0"
+        assert g[ip]["as_name"] == ""


### PR DESCRIPTION
Reserved addresses in geoip database return None for the AS Name, but default fields cc=ZZ and as=AS0. This fixes server error where AS Name was None and not validated.

Adds a test for lookups with such addresses. Fixes #1051