### PR TITLE
Remove bullseye backports

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONPATH /app/
 ENV DEBIAN_FRONTEND noninteractive

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:trixie
+FROM debian:bullseye
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONPATH /app/
 ENV DEBIAN_FRONTEND noninteractive

--- a/api/build_runner.sh
+++ b/api/build_runner.sh
@@ -7,7 +7,7 @@
 set -eu
 export DEBIAN_FRONTEND=noninteractive
 
-echo 'deb http://deb.debian.org/debian bullseye-backports main' \
+echo 'deb http://deb.debian.org/debian bookworm-backports main' \
   > /etc/apt/sources.list.d/backports.list
 
 # Install ca-certificates and gnupg first

--- a/api/build_runner.sh
+++ b/api/build_runner.sh
@@ -7,7 +7,7 @@
 set -eu
 export DEBIAN_FRONTEND=noninteractive
 
-echo 'deb http://deb.debian.org/debian trixie-backports main' \
+echo 'deb http://deb.debian.org/debian bullseye-backports main' \
   > /etc/apt/sources.list.d/backports.list
 
 # Install ca-certificates and gnupg first

--- a/api/ooniapi/app.py
+++ b/api/ooniapi/app.py
@@ -3,12 +3,11 @@ from __future__ import absolute_import
 import datetime
 import logging
 import os
-import json
 import re
 import sys
 from collections import deque
 
-from flask import Flask
+from flask import Flask, json
 
 from flask_cors import CORS  # debdeps: python3-flask-cors
 
@@ -33,7 +32,7 @@ from ooniapi.database import init_clickhouse_db
 APP_DIR = os.path.dirname(__file__)
 
 
-class JSONEncoderWithDates(json.JSONEncoder):
+class FlaskJSONEncoder(json.JSONEncoder):
     # Special JSON encoder that handles dates
     def default(self, o):
         if isinstance(o, datetime.datetime):
@@ -177,7 +176,7 @@ def create_app(*args, testmode=False, **kw):
     from ooniapi import views
 
     app = Flask(__name__)
-    app.json_encoder = JSONEncoderWithDates
+    app.json_encoder = FlaskJSONEncoder
 
     # Order matters
     init_app(app, testmode=testmode)

--- a/api/ooniapi/database.py
+++ b/api/ooniapi/database.py
@@ -6,7 +6,7 @@ import os
 from flask import current_app
 
 from sqlalchemy.dialects import postgresql
-from sqlalchemy.orm import declarative_base
+from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.sql.elements import TextClause
 from sqlalchemy.sql.selectable import Select
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -28,7 +28,7 @@ def app():
     return app
 
 
-@pytest.fixture
+@pytest.yield_fixture
 def client(app):
     """
     Overriding the `client` fixture from pytest_flask to fix this bug:
@@ -37,13 +37,12 @@ def client(app):
     with app.test_client() as client:
         yield client
 
-    # deprecated name _request_ctx_stack and marked as not a bug on issue #42
-    #while True:
-    #    top = flask._request_ctx_stack.top
-    #    if top is not None and top.preserved:
-    #        top.pop()
-    #    else:
-    #        break
+    while True:
+        top = flask._request_ctx_stack.top
+        if top is not None and top.preserved:
+            top.pop()
+        else:
+            break
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
maybe we're lucky and bookworm doesn't upgrade too many python packages