### PR TITLE
Fix bad response typing in /sign_credential

### DIFF
--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -758,7 +758,7 @@ class RegisterResponse(BaseModel):
 
 # TODO: choose a better name for this endpoint
 @router.post("/sign_credential", tags=["anonymous_credentials"])
-def sign_credential(register_request: RegisterRequest, manifest: ManifestDep, settings: SettingsDep):
+def sign_credential(register_request: RegisterRequest, manifest: ManifestDep, settings: SettingsDep) -> RegisterResponse:
 
     if register_request.manifest_version != manifest.meta.version:
         _raise_manifest_not_found(register_request.manifest_version)


### PR DESCRIPTION
The docs show that the response type of `/sign_credential` is a string, which is incorrect. This PR will add proper typing to the handler function so that docs show the right return type