### PR TITLE
Patch sign credential bug

### DIFF
--- a/ooniapi/services/ooniprobe/src/ooniprobe/main.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/main.py
@@ -54,9 +54,11 @@ async def lifespan(
 
     yield
 
+
 def init_ooniauth():
     # Creating a server state from scratch initializes the underlying crypto library
     ServerState()
+
 
 async def setup_repeating_tasks(settings: Settings):
     # Call all repeating tasks here to make them start
@@ -182,6 +184,7 @@ async def root():
     # TODO(art): fix this redirect by pointing health monitoring to /health
     # return RedirectResponse("/docs")
     return {"msg": "hello from ooniprobe"}
+
 
 def check_ooniauth_health():
     """


### PR DESCRIPTION
This PR will patch the userauth issue causing an error when trying to register a new user, see: #1092 

- Initializes the ooniauth library in lifespan
- Adds a healthcheck in `/health` that makes sure that ooniauth is initialized