### PR TITLE
Handle case of value already being none is nan_to_none

### DIFF
--- a/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/data/aggregate_analysis.py
+++ b/ooniapi/services/oonimeasurements/src/oonimeasurements/routers/data/aggregate_analysis.py
@@ -281,7 +281,7 @@ def format_aggregate_query(extra_cols: Dict[str, str], where: str):
     """
 
 
-def nan_to_none(val):
+def nan_to_none(val: Optional[float]):
     if val is None:
         return None
     if math.isnan(val):


### PR DESCRIPTION
Since we are now detecting many more events and not using pandas anymore it seems like the types have changed.

This makes the `nan_to_none` function be a bit more graceful is handling cases in which the value is already None