### PR TITLE
Add new explorer domain to fqdn valid list

### DIFF
--- a/ooniapi/services/ooniauth/src/ooniauth/utils.py
+++ b/ooniapi/services/ooniauth/src/ooniauth/utils.py
@@ -11,6 +11,7 @@ from .common.auth import create_jwt
 VALID_REDIRECT_TO_FQDN = (
     "explorer.ooni.org",
     "explorer.test.ooni.org",
+    "explorer.dev.ooni.org",
     "run.ooni.io",
     "run.ooni.org",
     "run.test.ooni.org",


### PR DESCRIPTION
This PR will add `explorer.dev.ooni.org` to the valid list of fqdn for valid redirections in ooniauth