### PR TITLE
Use a shared client across requests

### DIFF
--- a/ooniapi/services/ooniprobe/src/ooniprobe/main.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/main.py
@@ -3,6 +3,7 @@ from typing import Optional
 from contextlib import asynccontextmanager
 from urllib.request import urlopen
 
+import httpx
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -51,8 +52,13 @@ async def lifespan(
 
     if repeating_tasks_active:
         await setup_repeating_tasks(settings)
+    app.state.fastpath_client = httpx.AsyncClient(
+        timeout=httpx.Timeout(connect=5.0, read=30.0, write=10.0, pool=5.0)
+    )
 
     yield
+
+    await app.state.fastpath_client.aclose()
 
 
 def init_ooniauth():

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -998,13 +998,13 @@ async def submit_measurement(
 
     # Use exponential back off with jitter between retries to avoid choking the fastpath server
     # with many retries at the same time when there's a temporary issue
+    client = request.app.state.fastpath_client
     N_RETRIES = 3
     for t in range(N_RETRIES):
         try:
             url = f"{settings.fastpath_url}/{msmt_uid}"
 
-            async with httpx.AsyncClient() as client:
-                resp = await client.post(url, content=data_bin, timeout=59)
+            resp = await client.post(url, content=data_bin, timeout=59)
 
             assert resp.status_code == 200, resp.content
 


### PR DESCRIPTION
Explicitly set timeouts and make use of connection pooling