### PR TITLE
Disable vanilla Tor in probe services

### DIFF
--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -401,7 +401,7 @@ def check_in(
             # TODO(https://github.com/ooni/probe-cli/pull/1522): we disable torsf until we have
             # addressed the issue with the fast.ly based rendezvous method being broken
             "torsf_enabled": False,
-            "vanilla_tor_enabled": True,
+            "vanilla_tor_enabled": False,
             "openvpn_enabled": False,
         }
     )


### PR DESCRIPTION
This diff disables vanilla_tor in the probe services which should allow us to check if we can reduce tor crashes in the apps