### PR TITLE
Remove anonymous credentials fields from the database

### DIFF
--- a/fastpath/clickhouse_init.sql
+++ b/fastpath/clickhouse_init.sql
@@ -39,7 +39,7 @@ CREATE TABLE IF NOT EXISTS default.fastpath
     `test_helper_address` LowCardinality(String),
     `test_helper_type` LowCardinality(String),
     `ooni_run_link_id` Nullable(UInt64),
-    `is_verified` Int8,
+    `is_verified` LowCardinality(String),
 )
 ENGINE = ReplacingMergeTree
 ORDER BY (measurement_start_time, report_id, input)

--- a/fastpath/clickhouse_init.sql
+++ b/fastpath/clickhouse_init.sql
@@ -40,10 +40,6 @@ CREATE TABLE IF NOT EXISTS default.fastpath
     `test_helper_type` LowCardinality(String),
     `ooni_run_link_id` Nullable(UInt64),
     `is_verified` Int8,
-    `nym` Nullable(String),
-    `zkp_request` Nullable(String),
-    `age_range` Nullable(String),
-    `msm_range` Nullable(String),
 )
 ENGINE = ReplacingMergeTree
 ORDER BY (measurement_start_time, report_id, input)

--- a/fastpath/debian/changelog
+++ b/fastpath/debian/changelog
@@ -1,3 +1,10 @@
+fastpath (0.91) unstable; urgency=medium
+
+  * Remove zkp_request, nym, age_range, msm_range fields from the DB and
+    json
+
+ -- Luis Diaz <luis@openobservatory.org>  Wed, 08 Apr 2026 11:26:40 +0200
+
 fastpath (0.90) unstable; urgency=medium
 
   * Fix bad anonymous credentials measurement submission

--- a/fastpath/fastpath/core.py
+++ b/fastpath/fastpath/core.py
@@ -1657,10 +1657,6 @@ def process_measurement(msm_tup, buffer_writes=False) -> None:
             measurement = ujson.loads(msm_jstr)
 
         is_verified = g(measurement, 'is_verified', default=False)
-        nym = g(measurement, 'nym')
-        zkp_request = g(measurement, 'zkp_request')
-        age_range = g(measurement, 'age_range')
-        msm_range = g(measurement, 'msm_range')
 
         if "content" in measurement and "format" in measurement:
             measurement = unwrap_msmt(measurement)
@@ -1751,10 +1747,6 @@ def process_measurement(msm_tup, buffer_writes=False) -> None:
             test_helper_type,
             ooni_run_link_id,
             is_verified,
-            nym,
-            zkp_request,
-            age_range,
-            msm_range,
             buffer_writes=buffer_writes,
         )
 

--- a/fastpath/fastpath/db.py
+++ b/fastpath/fastpath/db.py
@@ -210,10 +210,6 @@ def clickhouse_upsert_summary(
     test_helper_type: str,
     ooni_run_link_id: Optional[int],
     is_verified: bool,
-    zkp_request: Optional[str],
-    nym: Optional[str],
-    age_range: Optional[Tuple[int, int]],
-    msm_range: Optional[Tuple[int, int]],
     buffer_writes=False,
 ) -> None:
     """Insert a row in the fastpath table. Overwrite an existing one."""
@@ -228,10 +224,6 @@ def clickhouse_upsert_summary(
 
     def tf(v: bool) -> str:
         return "t" if v else "f"
-
-    def serialize_optional(x : Optional[Any]) -> Optional[str]:
-        """Serialize to string if not None, return None otherwise"""
-        return ujson.dumps(x) if x is not None else None
 
     test_name = msm.get("test_name", None) or ""
     input_, domain = extract_input_domain(msm, test_name)
@@ -267,10 +259,6 @@ def clickhouse_upsert_summary(
         test_helper_type=test_helper_type,
         ooni_run_link_id=ooni_run_link_id,
         is_verified=tf(is_verified),
-        nym=nym,
-        zkp_request=zkp_request,
-        age_range=serialize_optional(age_range),
-        msm_range=serialize_optional(msm_range)
     )
 
     if buffer_writes:

--- a/fastpath/fastpath/tests/test_functional_nodb.py
+++ b/fastpath/fastpath/tests/test_functional_nodb.py
@@ -155,10 +155,6 @@ def test_score_web_connectivity_bug_610_2(fprints):
             "test_helper_type": "https",
             "ooni_run_link_id": None,
             "is_verified" : "f",
-            "nym" : None,
-            "zkp_request" : None,
-            "age_range" : None,
-            "msm_range" : None,
         }
     ]
 
@@ -207,10 +203,6 @@ def test_score_browser_web(fprints):
             "test_start_time": datetime.datetime(2023, 3, 20, 18, 26, 35),
             "test_version": "0.1.0",
             "is_verified" : "f",
-            "nym" : None,
-            "zkp_request" : None,
-            "age_range" : None,
-            "msm_range" : None,
         },
     ]
 
@@ -263,10 +255,6 @@ def test_score_openvpn():
             "test_helper_type": "",
             "ooni_run_link_id": None,
             "is_verified" : "f",
-            "nym" : None,
-            "zkp_request" : None,
-            "age_range" : None,
-            "msm_range" : None,
         }
     ]
 

--- a/ooniapi/services/oonimeasurements/tests/migrations/0_clickhouse_init_tables.sql
+++ b/ooniapi/services/oonimeasurements/tests/migrations/0_clickhouse_init_tables.sql
@@ -65,7 +65,7 @@ ENGINE = MergeTree
 ORDER BY (report_id, input)
 SETTINGS index_granularity = 8192;
 
-ALTER TABLE default.fastpath ADD COLUMN IF NOT EXISTS `is_verified` Int8;
+ALTER TABLE default.fastpath ADD COLUMN IF NOT EXISTS `is_verified` LowCardinality(String);
 CREATE TABLE IF NOT EXISTS default.event_detector_changepoints
 (
     `probe_asn` UInt32,

--- a/ooniapi/services/oonimeasurements/tests/migrations/0_clickhouse_init_tables.sql
+++ b/ooniapi/services/oonimeasurements/tests/migrations/0_clickhouse_init_tables.sql
@@ -66,10 +66,6 @@ ORDER BY (report_id, input)
 SETTINGS index_granularity = 8192;
 
 ALTER TABLE default.fastpath ADD COLUMN IF NOT EXISTS `is_verified` Int8;
-ALTER TABLE default.fastpath ADD COLUMN IF NOT EXISTS `nym` Nullable(String);
-ALTER TABLE default.fastpath ADD COLUMN IF NOT EXISTS `zkp_request` Nullable(String);
-ALTER TABLE default.fastpath ADD COLUMN IF NOT EXISTS `age_range` Nullable(String);
-ALTER TABLE default.fastpath ADD COLUMN IF NOT EXISTS `msm_range` Nullable(String);
 CREATE TABLE IF NOT EXISTS default.event_detector_changepoints
 (
     `probe_asn` UInt32,

--- a/ooniapi/services/ooniprobe/tests/fixtures/initdb/01-scheme.sql
+++ b/ooniapi/services/ooniprobe/tests/fixtures/initdb/01-scheme.sql
@@ -252,7 +252,3 @@ ORDER BY (ooni_run_link_id, descriptor_creation_time)
 SETTINGS index_granularity = 1;
 
 ALTER TABLE default.fastpath ADD COLUMN IF NOT EXISTS `is_verified` Int8;
-ALTER TABLE default.fastpath ADD COLUMN IF NOT EXISTS `nym` Nullable(String);
-ALTER TABLE default.fastpath ADD COLUMN IF NOT EXISTS `zkp_request` Nullable(String);
-ALTER TABLE default.fastpath ADD COLUMN IF NOT EXISTS `age_range` Nullable(String);
-ALTER TABLE default.fastpath ADD COLUMN IF NOT EXISTS `msm_range` Nullable(String);

--- a/ooniapi/services/testlists/tests/fixtures/initdb/01-scheme.sql
+++ b/ooniapi/services/testlists/tests/fixtures/initdb/01-scheme.sql
@@ -251,4 +251,4 @@ ENGINE = ReplacingMergeTree(translation_creation_time)
 ORDER BY (ooni_run_link_id, descriptor_creation_time)
 SETTINGS index_granularity = 1;
 
-ALTER TABLE default.fastpath ADD COLUMN IF NOT EXISTS `is_verified` Int8;
+ALTER TABLE default.fastpath ADD COLUMN IF NOT EXISTS `is_verified` LowCardinality(String);

--- a/ooniapi/services/testlists/tests/fixtures/initdb/01-scheme.sql
+++ b/ooniapi/services/testlists/tests/fixtures/initdb/01-scheme.sql
@@ -252,7 +252,3 @@ ORDER BY (ooni_run_link_id, descriptor_creation_time)
 SETTINGS index_granularity = 1;
 
 ALTER TABLE default.fastpath ADD COLUMN IF NOT EXISTS `is_verified` Int8;
-ALTER TABLE default.fastpath ADD COLUMN IF NOT EXISTS `nym` Nullable(String);
-ALTER TABLE default.fastpath ADD COLUMN IF NOT EXISTS `zkp_request` Nullable(String);
-ALTER TABLE default.fastpath ADD COLUMN IF NOT EXISTS `age_range` Nullable(String);
-ALTER TABLE default.fastpath ADD COLUMN IF NOT EXISTS `msm_range` Nullable(String);


### PR DESCRIPTION
This PR removes the following anonymous credentials fields from the DB: 

- `nym`
- `zkp_request`
- `age_range`
- `msm_range`

The fastpath version is also bumped

closes #1151 