### PR TITLE
Add more metrics to the ooniprobe service

### DIFF
--- a/ooniapi/services/ooniprobe/src/ooniprobe/metrics.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/metrics.py
@@ -36,7 +36,7 @@ class Metrics:
     )
 
     READ_BODY_TIMING = Histogram(
-        "measurement_read_body",
+        "measurement_read_body_seconds",
         "How long it took to read the measurement body",
     )
 

--- a/ooniapi/services/ooniprobe/src/ooniprobe/metrics.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/metrics.py
@@ -19,7 +19,7 @@ class Metrics:
         labelnames=["mismatch"],
     )
 
-    BAD_MEASUREMENTS = Counter(
+    BAD_MEASUREMENTS_CNT = Counter(
         "measurement_bad_count",
         "Measurements that are bad disaggregated by reason",
         labelnames=["reason"],
@@ -30,7 +30,7 @@ class Metrics:
         "How long it took compare the probe_cc and probe_asn",
     )
 
-    COMPARE_CC_FAILURE = Histogram(
+    COMPARE_CC_FAILURE = Counter(
         "measurement_compare_cc_failure_count",
         "How many times ooniprobe failed to compare the probe_cc and probe_asn",
     )

--- a/ooniapi/services/ooniprobe/src/ooniprobe/metrics.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/metrics.py
@@ -1,4 +1,4 @@
-from prometheus_client import Counter, Info, Gauge
+from prometheus_client import Counter, Gauge, Histogram, Info
 
 
 class Metrics:
@@ -15,7 +15,7 @@ class Metrics:
 
     MSMNT_RECEIVED_CNT = Counter(
         "receive_measurement_count",
-        "Count of incomming measurements",
+        "Count of incoming measurements",
     )
 
     PROBE_CC_ASN_MATCH = Counter(
@@ -29,19 +29,48 @@ class Metrics:
         labelnames=["mismatch"],
     )
 
-    MISSED_MSMNTS = Counter(
-        "missed_msmnts", "Measurements that failed to be sent to the fast path."
+    BAD_MEASUREMENTS = Counter(
+        "measurement_bad_count",
+        "Measurements that are bad disaggregated by reason",
+        labelnames=["reason"],
     )
 
-    SEND_FASTPATH_FAILURE = Counter(
-        "measurement_fastpath_send_failure_count",
+    COMPARE_CC_TIMING = Histogram(
+        "measurement_compare_cc_seconds",
+        "How long it took compare the probe_cc and probe_asn",
+    )
+
+    COMPARE_CC_FAILURE = Histogram(
+        "measurement_compare_cc_failure_count",
+        "How many times ooniprobe failed to compare the probe_cc and probe_asn",
+    )
+
+    READ_BODY_TIMING = Histogram(
+        "measurement_read_body",
+        "How long it took to read the measurement body",
+    )
+
+    SEND_FASTPATH_TIMING = Histogram(
+        "measurement_fastpath_send_seconds",
+        "How long it took to post the measurement to the fastpath",
+    )
+
+    SEND_S3_TIMING = Histogram(
+        "measurement_s3_upload_seconds",
+        "How long it took to send the measurement to s3",
+    )
+
+    SEND_FASTPATH_CNT = Counter(
+        "measurement_fastpath_send_count",
         "How many times ooniprobe failed to send a measurement to fastpath",
+        labelnames=["status"],
     )
 
-    SEND_S3_FAILURE = Counter(
-        "measurement_s3_upload_failure_count",
-        "How many times ooniprobe failed to send a measurement to s3. "
+    SEND_S3_CNT = Counter(
+        "measurement_s3_upload_count",
+        "How many times ooniprobe sent a measurement to s3 disaggregated by status"
         "Measurements are sent to s3 when they can't be sent to the fastpath",
+        labelnames=["status"],
     )
 
     # -- < Probe services > ----------------------------------------------------

--- a/ooniapi/services/ooniprobe/src/ooniprobe/metrics.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/metrics.py
@@ -2,6 +2,31 @@ from prometheus_client import Counter, Gauge, Histogram, Info
 
 
 class Metrics:
+    # Discontinued metrics TODO: switch to the new ones below:
+
+    # these two are part of the same metric disaggregated by status
+    MSMNT_DISCARD_ASN0 = Counter(
+        "receive_measurement_discard_asn_0",
+        "How many measurements were discarded due to probe_asn == ASN0",
+    )
+    MSMNT_DISCARD_CC_ZZ = Counter(
+        "receive_measurement_discard_cc_zz",
+        "How many measurements were discarded due to probe_cc == ZZ",
+    )
+    MISSED_MSMNTS = Counter(
+        "missed_msmnts", "Measurements that failed to be sent to the fast path."
+    )
+
+    # These are now part of SEND_*_CNT disaggregated by status
+    SEND_FASTPATH_FAILURE = Counter(
+        "measurement_fastpath_send_failure_count",
+        "How many times ooniprobe failed to send a measurement to fastpath",
+    )
+    SEND_S3_FAILURE = Counter(
+        "measurement_s3_upload_failure_count",
+        "How many times ooniprobe failed to send a measurement to s3. ",
+    )
+
     # -- < Measurement submission > ------------------------------------
     MSMNT_RECEIVED_CNT = Counter(
         "receive_measurement_count",

--- a/ooniapi/services/ooniprobe/src/ooniprobe/metrics.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/metrics.py
@@ -3,16 +3,6 @@ from prometheus_client import Counter, Gauge, Histogram, Info
 
 class Metrics:
     # -- < Measurement submission > ------------------------------------
-    MSMNT_DISCARD_ASN0 = Counter(
-        "receive_measurement_discard_asn_0",
-        "How many measurements were discarded due to probe_asn == ASN0",
-    )
-
-    MSMNT_DISCARD_CC_ZZ = Counter(
-        "receive_measurement_discard_cc_zz",
-        "How many measurements were discarded due to probe_cc == ZZ",
-    )
-
     MSMNT_RECEIVED_CNT = Counter(
         "receive_measurement_count",
         "Count of incoming measurements",

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
@@ -117,6 +117,7 @@ async def receive_measurement(
         log.info(
             f"Unexpected report_id {report_id[:200]}. Error: {e}",
         )
+        Metrics.BAD_MEASUREMENTS.labels(reason="bad_report_id").inc()
         raise error("Incorrect format")
 
     # TODO validate the timestamp?
@@ -129,19 +130,22 @@ async def receive_measurement(
         asn_i = int(asn)
     except ValueError as e:
         log.info(f"ASN value not parsable {asn}. Error: {e}")
+        Metrics.BAD_MEASUREMENTS.labels(reason="bad_asn").inc()
         error("Incorrect format")
 
     if asn_i == 0:
         log.info("Discarding ASN == 0")
-        Metrics.MSMNT_DISCARD_ASN0.inc()
+        Metrics.BAD_MEASUREMENTS.labels(reason="asn_0").inc()
         return empty_measurement
 
     if cc.upper() == "ZZ":
         log.info("Discarding CC == ZZ")
-        Metrics.MSMNT_DISCARD_CC_ZZ.inc()
+        Metrics.BAD_MEASUREMENTS.labels(reason="cc_zz").inc()
         return empty_measurement
 
-    data = await request.body()
+    with Metrics.READ_BODY_TIMING.time():
+        data = await request.body()
+
     if content_encoding == "zstd":
         try:
             compressed_len = len(data)
@@ -149,6 +153,7 @@ async def receive_measurement(
             log.debug(f"Zstd compression ratio {compressed_len / len(data)}")
         except Exception as e:
             log.info(f"Failed zstd decompression. Error: {e}")
+            Metrics.BAD_MEASUREMENTS.labels(reason="zstd_fail").inc()
             error("Incorrect format")
 
     # Write the whole body of the measurement in a directory based on a 1-hour
@@ -161,24 +166,26 @@ async def receive_measurement(
     msmt_uid = f"{ts}_{cc}_{test_name}_{h}"
     Metrics.MSMNT_RECEIVED_CNT.inc()
 
-    try:
-        await run_in_threadpool(
-            compare_probe_msmt_cc_asn,
-            msmt_uid,
-            cc,
-            asn,
-            request,
-            cc_reader,
-            asn_reader,
-            clickhouse,
-        )
-    except Exception:
-        log.exception("failed to compared probe_msmt_cc_asn")
+    with Metrics.COMPARE_CC_TIMING.time():
+        try:
+            await run_in_threadpool(
+                compare_probe_msmt_cc_asn,
+                msmt_uid,
+                cc,
+                asn,
+                request,
+                cc_reader,
+                asn_reader,
+                clickhouse,
+            )
+        except Exception:
+            log.exception("failed to compared probe_msmt_cc_asn")
+            Metrics.COMPARE_CC_FAILURE.inc()
 
     # Use exponential back off with jitter between retries
     client = request.app.state.fastpath_client
-    N_RETRIES = 3
-    for t in range(N_RETRIES):
+
+    with Metrics.SEND_FASTPATH_TIMING.time():
         try:
             url = f"{settings.fastpath_url}/{msmt_uid}"
 
@@ -189,35 +196,32 @@ async def receive_measurement(
                     f"Unexpected status {resp.status_code}: {resp.content}"
                 )
 
+            Metrics.SEND_FASTPATH_CNT.labels(status="ok").inc()
             return ReceiveMeasurementResponse(measurement_uid=msmt_uid)
 
         except Exception:
-            Metrics.SEND_FASTPATH_FAILURE.inc()
-            sleep_time = random.uniform(0.3, 2 ** (t + 1))
-            log.exception(
-                f"[Try {t + 1}/{N_RETRIES}] Error trying to send measurement to the fastpath ({settings.fastpath_url}). Sleeping for {sleep_time}s"
-            )
-            await asyncio.sleep(sleep_time)
+            log.exception("Unable to send measurement to fastpath")
+            Metrics.SEND_FASTPATH_CNT.labels(status="fail").inc()
 
     # wasn't possible to send msmnt to fastpath, try to send it to s3
     ts_prefix = now.strftime("%Y%m%d%H")
     tn = test_name.replace("_", "")
     s3_key = f"postcans/{ts_prefix}/{ts_prefix}_{cc}_{tn}/{msmt_uid}.post"
-    try:
-        await run_in_threadpool(
-            request.app.state.s3_client.upload_fileobj,
-            io.BytesIO(data),
-            Bucket=settings.failed_reports_bucket,
-            Key=s3_key,
-        )
-    except Exception:
-        log.exception("Unable to upload measurement to s3")
-        Metrics.SEND_S3_FAILURE.inc()
-        return empty_measurement
-
-    log.error(f"Unable to send report to fastpath. measurement_uid: {msmt_uid}")
-    Metrics.MISSED_MSMNTS.inc()
-    return empty_measurement
+    with Metrics.SEND_S3_TIMING.time():
+        try:
+            await run_in_threadpool(
+                request.app.state.s3_client.upload_fileobj,
+                io.BytesIO(data),
+                Bucket=settings.failed_reports_bucket,
+                Key=s3_key,
+            )
+            Metrics.SEND_S3_CNT.labels(status="ok").inc()
+            log.error(f"Unable to send report to fastpath. measurement_uid: {msmt_uid}")
+            return empty_measurement
+        except Exception:
+            log.exception("Unable to upload measurement to s3")
+            Metrics.SEND_S3_CNT.labels(status="fail").inc()
+            return empty_measurement
 
 
 @timer(name="close_report")

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
@@ -117,7 +117,7 @@ async def receive_measurement(
         log.info(
             f"Unexpected report_id {report_id[:200]}. Error: {e}",
         )
-        Metrics.BAD_MEASUREMENTS.labels(reason="bad_report_id").inc()
+        Metrics.BAD_MEASUREMENTS_CNT.labels(reason="bad_report_id").inc()
         raise error("Incorrect format")
 
     # TODO validate the timestamp?
@@ -130,17 +130,17 @@ async def receive_measurement(
         asn_i = int(asn)
     except ValueError as e:
         log.info(f"ASN value not parsable {asn}. Error: {e}")
-        Metrics.BAD_MEASUREMENTS.labels(reason="bad_asn").inc()
+        Metrics.BAD_MEASUREMENTS_CNT.labels(reason="bad_asn").inc()
         error("Incorrect format")
 
     if asn_i == 0:
         log.info("Discarding ASN == 0")
-        Metrics.BAD_MEASUREMENTS.labels(reason="asn_0").inc()
+        Metrics.BAD_MEASUREMENTS_CNT.labels(reason="asn_0").inc()
         return empty_measurement
 
     if cc.upper() == "ZZ":
         log.info("Discarding CC == ZZ")
-        Metrics.BAD_MEASUREMENTS.labels(reason="cc_zz").inc()
+        Metrics.BAD_MEASUREMENTS_CNT.labels(reason="cc_zz").inc()
         return empty_measurement
 
     with Metrics.READ_BODY_TIMING.time():
@@ -153,7 +153,7 @@ async def receive_measurement(
             log.debug(f"Zstd compression ratio {compressed_len / len(data)}")
         except Exception as e:
             log.info(f"Failed zstd decompression. Error: {e}")
-            Metrics.BAD_MEASUREMENTS.labels(reason="zstd_fail").inc()
+            Metrics.BAD_MEASUREMENTS_CNT.labels(reason="zstd_fail").inc()
             error("Incorrect format")
 
     # Write the whole body of the measurement in a directory based on a 1-hour

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -963,6 +963,22 @@ async def submit_measurement(
     msmt_uid = f"{ts}_{cc}_{test_name}_{h}"
     Metrics.MSMNT_RECEIVED_CNT.inc()
 
+    with Metrics.COMPARE_CC_TIMING.time():
+        try:
+            await run_in_threadpool(
+                compare_probe_msmt_cc_asn,
+                msmt_uid,
+                cc,
+                asn,
+                request,
+                cc_reader,
+                asn_reader,
+                clickhouse,
+            )
+        except Exception:
+            log.exception("failed to compared probe_msmt_cc_asn")
+            Metrics.COMPARE_CC_FAILURE.inc()
+
     # Use exponential back off with jitter between retries to avoid choking the fastpath server
     # with many retries at the same time when there's a temporary issue
     client = request.app.state.fastpath_client
@@ -975,16 +991,6 @@ async def submit_measurement(
 
             assert resp.status_code == 200, resp.content
 
-            await run_in_threadpool(
-                compare_probe_msmt_cc_asn,
-                msmt_uid,
-                cc,
-                asn,
-                request,
-                cc_reader,
-                asn_reader,
-                clickhouse,
-            )
             return SubmitMeasurementResponse(
                 measurement_uid=msmt_uid,
                 is_verified=is_verified,

--- a/ooniapi/services/ooniprobe/src/ooniprobe/utils.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/utils.py
@@ -4,32 +4,28 @@ VPN Services
 Insert VPN credentials into database.
 """
 
-import itertools
-import logging
-from typing import List, TypedDict, Tuple
 import io
+import itertools
 import json
-
-from fastapi import Request
-from typing import Dict, Any
-
-from fastapi import HTTPException
-
-from mypy_boto3_s3 import S3Client
-from sqlalchemy.orm import Session
-import pem
+import logging
 from base64 import b64encode
 from datetime import datetime, timezone
 from os import urandom
+from typing import Any, Dict, List, Tuple, TypedDict
 
 import httpx
+import pem
+from fastapi import HTTPException, Request
+from mypy_boto3_s3 import S3Client
+from sqlalchemy.orm import Session
 
-from .metrics import Metrics
-from .common.config import Settings
-from .common.clickhouse_utils import insert_click
-from .common.dependencies import ClickhouseDep
-from .dependencies import CCReaderDep, ASNReaderDep
 from ooniprobe.models import OONIProbeVPNProvider, OONIProbeVPNProviderEndpoint
+
+from .common.clickhouse_utils import insert_click
+from .common.config import Settings
+from .common.dependencies import ClickhouseDep
+from .dependencies import ASNReaderDep, CCReaderDep
+from .metrics import Metrics
 
 RISEUP_CA_URL = "https://api.black.riseup.net/ca.crt"
 RISEUP_CERT_URL = "https://api.black.riseup.net/3/cert"
@@ -100,7 +96,7 @@ def upsert_endpoints(
     db: Session, new_endpoints: List[OpenVPNEndpoint], provider: OONIProbeVPNProvider
 ):
     new_endpoints_map = {
-        f'{ep["address"]}-{ep["protocol"]}-{ep["transport"]}': ep
+        f"{ep['address']}-{ep['protocol']}-{ep['transport']}": ep
         for ep in new_endpoints
     }
     for endpoint in provider.endpoints:
@@ -174,45 +170,41 @@ def compare_probe_msmt_cc_asn(
     """Compares CC/ASN from measurement with CC/ASN from HTTPS connection ipaddr
     Generates a metric.
     """
-    try:
-        cc = cc.upper()
-        ipaddr = extract_probe_ipaddr(request)
-        db_cc = lookup_probe_cc(ipaddr, cc_reader)
-        db_asn, _ = lookup_probe_network(ipaddr, asn_reader)
+    cc = cc.upper()
+    ipaddr = extract_probe_ipaddr(request)
+    db_cc = lookup_probe_cc(ipaddr, cc_reader)
+    db_asn, _ = lookup_probe_network(ipaddr, asn_reader)
 
-        if db_asn.startswith("AS"):
-            db_asn = db_asn[2:]
-        if db_cc == cc and db_asn == asn:
-            Metrics.PROBE_CC_ASN_MATCH.inc()
-        if db_cc != cc:
-            Metrics.PROBE_CC_ASN_NO_MATCH.labels(mismatch="cc").inc()
-        if db_asn != asn:
-            Metrics.PROBE_CC_ASN_NO_MATCH.labels(mismatch="asn").inc()
+    if db_asn.startswith("AS"):
+        db_asn = db_asn[2:]
+    if db_cc == cc and db_asn == asn:
+        Metrics.PROBE_CC_ASN_MATCH.inc()
+    if db_cc != cc:
+        Metrics.PROBE_CC_ASN_NO_MATCH.labels(mismatch="cc").inc()
+    if db_asn != asn:
+        Metrics.PROBE_CC_ASN_NO_MATCH.labels(mismatch="asn").inc()
 
-        if db_asn != asn or db_cc != cc:
-            details = json.dumps(
-                {
-                    "submission_cc": cc,
-                    "submission_asn": int(asn),
-                    "measurement_uid": measurement_uid,
-                }
-            )
+    if db_asn != asn or db_cc != cc:
+        details = json.dumps(
+            {
+                "submission_cc": cc,
+                "submission_asn": int(asn),
+                "measurement_uid": measurement_uid,
+            }
+        )
 
-            insert_click(
-                clickhouse,
-                """
-                INSERT INTO faulty_measurements (type, probe_cc, probe_asn, details)
-                SETTINGS
-                    async_insert=1,
-                    wait_for_async_insert=0
-                VALUES
-                """,
-                [("geoip", db_cc, int(db_asn), details)],
-                max_execution_time=5,
-            )
-
-    except Exception as e:
-        log.error(f"Error comparing msm cc and asn: {e}")
+        insert_click(
+            clickhouse,
+            """
+            INSERT INTO faulty_measurements (type, probe_cc, probe_asn, details)
+            SETTINGS
+                async_insert=1,
+                wait_for_async_insert=0
+            VALUES
+            """,
+            [("geoip", db_cc, int(db_asn), details)],
+            max_execution_time=5,
+        )
 
 
 def get_first_ip(headers: str) -> str:

--- a/ooniapi/services/ooniprobe/tests/test_anoncred.py
+++ b/ooniapi/services/ooniprobe/tests/test_anoncred.py
@@ -87,7 +87,7 @@ async def test_submission_basic(client):
     msm = make_measurement(submit_request.nym, submit_request.request, emission_day, manifest_version)
 
     c = postj(client, f"/api/v1/submit_measurement/{rid}", msm)
-    assert c['is_verified'] is True
+    assert c['is_verified'] is True, c
 
     assert c['submit_response'], "Submit response should not be null if the proof was verified"
     user.handle_submit_response(c['submit_response'])

--- a/ooniapi/services/ooniprobe/tests/test_anoncred.py
+++ b/ooniapi/services/ooniprobe/tests/test_anoncred.py
@@ -87,7 +87,7 @@ async def test_submission_basic(client):
     msm = make_measurement(submit_request.nym, submit_request.request, emission_day, manifest_version)
 
     c = postj(client, f"/api/v1/submit_measurement/{rid}", msm)
-    assert c['is_verified'] is True, c
+    assert 'is_verified' in c and c['is_verified'] is True, c
 
     assert c['submit_response'], "Submit response should not be null if the proof was verified"
     user.handle_submit_response(c['submit_response'])


### PR DESCRIPTION
* Remove `missed_msmnts` metric as it's redundant
* Create `measurement_bad_count` metric disaggregated by `reason` (replaces `receive_measurement_discard_asn_0` and `receive_measurement_discard_cc_zz`)

Add new metrics:
* `measurement_compare_cc_seconds`
* `measurement_compare_cc_failure_count`
* `measurement_read_body_seconds`
* `measurement_fastpath_send_seconds`
* `measurement_s3_upload_seconds`
* `measurement_fastpath_send_count` disaggregated by status
* `measurement_s3_upload_count` disaggregated by status