### PR TITLE
catch exceptions raised by db

### DIFF
--- a/fastpath/fastpath/core.py
+++ b/fastpath/fastpath/core.py
@@ -1857,8 +1857,11 @@ def update_fingerprints_if_needed() -> None:
         return  # too early
 
     log.info("Updating fingerprints")
-    dns_fp, http_fp = db.fetch_fingerprints()
-    fingerprints = prepare_fingerprints(dns_fp, http_fp)
+    try:
+        dns_fp, http_fp = db.fetch_fingerprints()
+        fingerprints = prepare_fingerprints(dns_fp, http_fp)
+    except Exception as e:
+        log.error(f"Uncaught exception {e}")
 
 
 def main():


### PR DESCRIPTION
This try/except should catch exceptions raised, for example, from a clickhouse connection timeout, that would otherwise cause the worker routine to exit.