### PR TITLE
/Health  returns error when there's at the least one bad health check

### DIFF
--- a/ooniapi/services/ooniauth/src/ooniauth/main.py
+++ b/ooniapi/services/ooniauth/src/ooniauth/main.py
@@ -89,8 +89,8 @@ async def health(
         "version": pkg_version,
         "build_label": build_label,
     }
-    if len(errors) > 0:
-        log.error(f"Health check errors: {errors}")
+    if len(errors):
+        log.error(f"Health check errors detected: {errors}")
 
     return JSONResponse(content=result, status_code=code)
 

--- a/ooniapi/services/ooniauth/src/ooniauth/main.py
+++ b/ooniapi/services/ooniauth/src/ooniauth/main.py
@@ -82,17 +82,17 @@ async def health(
     if settings.aws_secret_access_key == "" or settings.aws_access_key_id == "":
         errors.append("bad_aws_credentials")
 
+    status, code = ("ok", 200) if len(errors) == 0 else ("fail", 503)
     result = {
-        "status": "ok" if len(errors) == 0 else "fail",
+        "status": status,
         "errors": errors,
         "version": pkg_version,
         "build_label": build_label,
     }
     if len(errors) > 0:
         log.error(f"Health check errors: {errors}")
-        return JSONResponse(status_code=503, content=result)
 
-    return result
+    return JSONResponse(content=result, status_code=code)
 
 
 @app.get("/")

--- a/ooniapi/services/ooniauth/src/ooniauth/main.py
+++ b/ooniapi/services/ooniauth/src/ooniauth/main.py
@@ -1,8 +1,9 @@
 import logging
 from contextlib import asynccontextmanager
 
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from pydantic import BaseModel
 
@@ -81,15 +82,17 @@ async def health(
     if settings.aws_secret_access_key == "" or settings.aws_access_key_id == "":
         errors.append("bad_aws_credentials")
 
-    if len(errors) > 0:
-        log.error(f"Health check errors: {errors}")
-        raise HTTPException(status_code=542, detail=f"health check failed")
-
-    return {
-        "status": "ok",
+    result = {
+        "status": "ok" if len(errors) == 0 else "fail",
+        "errors": errors,
         "version": pkg_version,
         "build_label": build_label,
     }
+    if len(errors) > 0:
+        log.error(f"Health check errors: {errors}")
+        return JSONResponse(status_code=503, content=result)
+
+    return result
 
 
 @app.get("/")

--- a/ooniapi/services/oonifindings/src/oonifindings/main.py
+++ b/ooniapi/services/oonifindings/src/oonifindings/main.py
@@ -86,16 +86,14 @@ async def health(
         log.error(err)
         errors.append(err)
 
+    status, code = ("ok", 200) if len(errors) == 0 else ("fail", 503)
     result = {
-        "status": "ok" if len(errors) == 0 else "fail",
+        "status": status,
         "errors": errors,
         "version": pkg_version,
         "build_label": build_label,
     }
-    if len(errors) > 0:
-        return JSONResponse(status_code=503, content=result)
-
-    return result
+    return JSONResponse(content=result, status_code=code)
 
 
 @app.get("/")

--- a/ooniapi/services/oonifindings/src/oonifindings/main.py
+++ b/ooniapi/services/oonifindings/src/oonifindings/main.py
@@ -93,6 +93,9 @@ async def health(
         "version": pkg_version,
         "build_label": build_label,
     }
+    if len(errors):
+        log.error(f"Health check errors detected: {errors}")
+
     return JSONResponse(content=result, status_code=code)
 
 

--- a/ooniapi/services/oonifindings/src/oonifindings/main.py
+++ b/ooniapi/services/oonifindings/src/oonifindings/main.py
@@ -1,8 +1,9 @@
 import logging
 from contextlib import asynccontextmanager
 
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from pydantic import BaseModel
 
@@ -85,16 +86,16 @@ async def health(
         log.error(err)
         errors.append(err)
 
-    status = "ok"
-    if len(errors) > 0:
-        status = "fail"
-
-    return {
-        "status": status,
+    result = {
+        "status": "ok" if len(errors) == 0 else "fail",
         "errors": errors,
         "version": pkg_version,
         "build_label": build_label,
     }
+    if len(errors) > 0:
+        return JSONResponse(status_code=503, content=result)
+
+    return result
 
 
 @app.get("/")

--- a/ooniapi/services/oonifindings/tests/test_main.py
+++ b/ooniapi/services/oonifindings/tests/test_main.py
@@ -16,7 +16,7 @@ def test_health_good(client):
 def test_health_bad(client_with_bad_settings):
     r = client_with_bad_settings.get("health")
     j = r.json()
-    assert r.status_code == 200
+    assert r.status_code == 503
     assert j["status"] == "fail", j
 
 

--- a/ooniapi/services/oonimeasurements/src/oonimeasurements/main.py
+++ b/ooniapi/services/oonimeasurements/src/oonimeasurements/main.py
@@ -2,6 +2,7 @@ import logging
 
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from prometheus_fastapi_instrumentator import Instrumentator
 from pydantic import BaseModel
 
@@ -98,16 +99,16 @@ def setup_router(app: FastAPI):
             log.error(err)
             errors.append(err)
 
-        status = "ok"
-        if len(errors) > 0:
-            status = "fail"
-
-        return {
-            "status": status,
+        result = {
+            "status": "ok" if len(errors) == 0 else "fail",
             "errors": errors,
             "version": pkg_version,
             "build_label": build_label,
         }
+        if len(errors) > 0:
+            return JSONResponse(status_code=503, content=result)
+
+        return result
 
     @app.get("/")
     async def root():

--- a/ooniapi/services/oonimeasurements/src/oonimeasurements/main.py
+++ b/ooniapi/services/oonimeasurements/src/oonimeasurements/main.py
@@ -99,16 +99,14 @@ def setup_router(app: FastAPI):
             log.error(err)
             errors.append(err)
 
+        status, code = ("ok", 200) if len(errors) == 0 else ("fail", 503)
         result = {
-            "status": "ok" if len(errors) == 0 else "fail",
+            "status": status,
             "errors": errors,
             "version": pkg_version,
             "build_label": build_label,
         }
-        if len(errors) > 0:
-            return JSONResponse(status_code=503, content=result)
-
-        return result
+        return JSONResponse(content=result, status_code=code)
 
     @app.get("/")
     async def root():

--- a/ooniapi/services/oonimeasurements/src/oonimeasurements/main.py
+++ b/ooniapi/services/oonimeasurements/src/oonimeasurements/main.py
@@ -106,6 +106,10 @@ def setup_router(app: FastAPI):
             "version": pkg_version,
             "build_label": build_label,
         }
+
+        if len(errors):
+            log.error(f"Health check errors detected: {errors}")
+
         return JSONResponse(content=result, status_code=code)
 
     @app.get("/")

--- a/ooniapi/services/oonimeasurements/tests/test_main.py
+++ b/ooniapi/services/oonimeasurements/tests/test_main.py
@@ -15,7 +15,7 @@ def test_health_bad(client_with_bad_settings):
     j = r.json()
     print(j)
     assert j["status"] == "fail", j
-    assert r.status_code == 200
+    assert r.status_code == 503
 
 
 def test_metrics(app):

--- a/ooniapi/services/ooniprobe/src/ooniprobe/main.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/main.py
@@ -167,17 +167,16 @@ async def health(
         errors.append("anonc_manifest_unreachable")
         log.error(f"Error retrieving manifest: {e}")
 
+    status, code = ("ok", 200) if len(errors) == 0 else ("fail", 503)
     result = {
-        "status": "ok" if len(errors) == 0 else "fail",
+        "status": status,
         "errors": errors,
         "version": VERSION,
         "build_label": build_label,
     }
 
-    if len(errors) > 0:
-        return JSONResponse(status_code=503, content=result)
 
-    return result
+    return JSONResponse(content=result, status_code=code)
 
 
 @app.get("/")

--- a/ooniapi/services/ooniprobe/src/ooniprobe/main.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/main.py
@@ -168,14 +168,13 @@ async def health(
         log.error(f"Error retrieving manifest: {e}")
 
     result = {
-        "status": "ok",
+        "status": "ok" if len(errors) == 0 else "fail",
         "errors": errors,
         "version": VERSION,
         "build_label": build_label,
     }
 
     if len(errors) > 0:
-        result["status"] = "fail"
         return JSONResponse(status_code=503, content=result)
 
     return result

--- a/ooniapi/services/ooniprobe/src/ooniprobe/main.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/main.py
@@ -176,7 +176,7 @@ async def health(
 
     if len(errors) > 0:
         result["status"] = "fail"
-        return JSONResponse(status_code=500, content=result)
+        return JSONResponse(status_code=503, content=result)
 
     return result
 

--- a/ooniapi/services/ooniprobe/src/ooniprobe/main.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/main.py
@@ -175,6 +175,9 @@ async def health(
         "build_label": build_label,
     }
 
+    if len(errors):
+        log.error(f"Health check errors detected: {errors}")
+
 
     return JSONResponse(content=result, status_code=code)
 

--- a/ooniapi/services/ooniprobe/src/ooniprobe/main.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/main.py
@@ -180,7 +180,7 @@ async def health(
     }
 
     if len(errors) > 0:
-        result['status '] = "fail"
+        result['status'] = "fail"
         raise HTTPException(500, result)
 
     return result

--- a/ooniapi/services/ooniprobe/src/ooniprobe/main.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/main.py
@@ -3,7 +3,8 @@ from contextlib import asynccontextmanager
 from typing import Optional
 
 import boto3
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 import requests
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi_utils.tasks import repeat_every
@@ -174,8 +175,8 @@ async def health(
     }
 
     if len(errors) > 0:
-        result['status'] = "fail"
-        raise HTTPException(500, result)
+        result["status"] = "fail"
+        return JSONResponse(status_code=500, content=result)
 
     return result
 

--- a/ooniapi/services/ooniprobe/src/ooniprobe/main.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/main.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import boto3
 import httpx
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi_utils.tasks import repeat_every
 from ooniauth_py import ServerState
@@ -172,16 +172,18 @@ async def health(
         errors.append("anonc_manifest_unreachable")
         log.error(f"Error retrieving manifest: {e}")
 
-    status = "ok"
-    if len(errors) > 0:
-        status = "fail"
-
-    return {
-        "status": status,
+    result = {
+        "status": "ok",
         "errors": errors,
         "version": VERSION,
         "build_label": build_label,
     }
+
+    if len(errors) > 0:
+        result['status '] = "fail"
+        raise HTTPException(500, result)
+
+    return result
 
 
 @app.get("/")

--- a/ooniapi/services/oonirun/src/oonirun/main.py
+++ b/ooniapi/services/oonirun/src/oonirun/main.py
@@ -100,6 +100,9 @@ async def health(
         "version": pkg_version,
         "build_label": build_label,
     }
+    if len(errors):
+        log.error(f"Health check errors detected: {errors}")
+
     return JSONResponse(content=result, status_code=code)
 
 

--- a/ooniapi/services/oonirun/src/oonirun/main.py
+++ b/ooniapi/services/oonirun/src/oonirun/main.py
@@ -93,16 +93,14 @@ async def health(
     if settings.prometheus_metrics_password == "CHANGEME":
         errors.append("bad_prometheus_password")
 
+    status, code = ("ok", 200) if len(errors) == 0 else ("fail", 503)
     result = {
-        "status": "ok" if len(errors) == 0 else "fail",
+        "status": status,
         "errors": errors,
         "version": pkg_version,
         "build_label": build_label,
     }
-    if len(errors) > 0:
-        return JSONResponse(status_code=503, content=result)
-
-    return result
+    return JSONResponse(content=result, status_code=code)
 
 
 @app.get("/")

--- a/ooniapi/services/oonirun/src/oonirun/main.py
+++ b/ooniapi/services/oonirun/src/oonirun/main.py
@@ -1,8 +1,9 @@
 import logging
 from contextlib import asynccontextmanager
 
-from fastapi import Depends, FastAPI
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from pydantic import BaseModel
 
@@ -12,7 +13,6 @@ from . import models
 from .routers import v2
 
 from .common.dependencies import get_settings, SettingsDep, ClickhouseDep, PostgresDep
-from .common.version import get_build_label, get_pkg_version
 from .common.version import get_build_label, get_pkg_version
 from .common.metrics import mount_metrics
 from .common.clickhouse_utils import query_click
@@ -93,16 +93,16 @@ async def health(
     if settings.prometheus_metrics_password == "CHANGEME":
         errors.append("bad_prometheus_password")
 
-    status = "ok"
-    if len(errors) > 0:
-        status = "fail"
-
-    return {
-        "status":   status,
-        "errors":   errors,
-        "version":  pkg_version,
+    result = {
+        "status": "ok" if len(errors) == 0 else "fail",
+        "errors": errors,
+        "version": pkg_version,
         "build_label": build_label,
     }
+    if len(errors) > 0:
+        return JSONResponse(status_code=503, content=result)
+
+    return result
 
 
 @app.get("/")

--- a/ooniapi/services/testlists/src/testlists/main.py
+++ b/ooniapi/services/testlists/src/testlists/main.py
@@ -129,16 +129,16 @@ async def health(
     if settings.prometheus_metrics_password == "CHANGEME":
         errors.append("bad_prometheus_password")
 
-    status = "ok"
-    if len(errors) > 0:
-        status = "fail"
-
-    return {
-        "status": status,
+    result = {
+        "status": "ok" if len(errors) == 0 else "fail",
         "errors": errors,
         "version": VERSION,
         "build_label": build_label,
     }
+    if len(errors) > 0:
+        return JSONResponse(status_code=503, content=result)
+
+    return result
 
 
 @app.get("/")

--- a/ooniapi/services/testlists/src/testlists/main.py
+++ b/ooniapi/services/testlists/src/testlists/main.py
@@ -3,11 +3,9 @@ from typing import Optional
 from contextlib import asynccontextmanager
 from urllib.request import urlopen
 
-from fastapi import Depends, FastAPI
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-
-from fastapi_utils.tasks import repeat_every
 
 from pydantic import BaseModel
 
@@ -136,6 +134,9 @@ async def health(
         "version": VERSION,
         "build_label": build_label,
     }
+    if len(errors):
+        log.error(f"Health check errors detected: {errors}")
+
     return JSONResponse(content=result, status_code=code)
 
 

--- a/ooniapi/services/testlists/src/testlists/main.py
+++ b/ooniapi/services/testlists/src/testlists/main.py
@@ -129,16 +129,14 @@ async def health(
     if settings.prometheus_metrics_password == "CHANGEME":
         errors.append("bad_prometheus_password")
 
+    status, code = ("ok", 200) if len(errors) == 0 else ("fail", 503)
     result = {
-        "status": "ok" if len(errors) == 0 else "fail",
+        "status": status,
         "errors": errors,
         "version": VERSION,
         "build_label": build_label,
     }
-    if len(errors) > 0:
-        return JSONResponse(status_code=503, content=result)
-
-    return result
+    return JSONResponse(content=result, status_code=code)
 
 
 @app.get("/")


### PR DESCRIPTION
- Returns `503` on health check error on all `/health` endpoints
- Logs the errors when present 
- Updates some tests accordingly 

closes #1173 