### PR TITLE
use requests.Session to re-use connections

### DIFF
--- a/ooniapi/services/ooniprobe/src/ooniprobe/main.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/main.py
@@ -48,8 +48,11 @@ async def lifespan(
     if repeating_tasks_active:
         await setup_repeating_tasks(settings)
     app.state.s3_client = boto3.client("s3")
+    app.state.fastpath_client = requests.Session()
 
     yield
+
+    app.state.fastpath_client.close()
 
 
 def init_ooniauth():
@@ -123,8 +126,9 @@ async def health(
         log.error(e)
 
     try:
-        resp = await run_in_threadpool(requests.get, settings.fastpath_url)
-        resp.raise_for_status()
+        resp = await run_in_threadpool(app.state.fastpath_client.get, settings.fastpath_url)
+        with resp:
+            resp.raise_for_status()
     except Exception as exc:
         log.error(str(exc))
         errors.append("fastpath_connection_error")

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
@@ -1,7 +1,5 @@
-import asyncio
 import io
 import logging
-import random
 from datetime import datetime, timezone
 from hashlib import sha512
 from typing import Any, Dict, List
@@ -15,7 +13,7 @@ from ..common.dependencies import ClickhouseDep
 from ..common.metrics import timer
 from ..common.routers import BaseModel
 from ..common.utils import setnocacheresponse
-from ..dependencies import ASNReaderDep, CCReaderDep, S3ClientDep, SettingsDep
+from ..dependencies import ASNReaderDep, CCReaderDep, SettingsDep
 from ..metrics import Metrics
 from ..utils import (
     compare_probe_msmt_cc_asn,

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
@@ -2,7 +2,6 @@ import asyncio
 import io
 import logging
 import random
-import requests
 from datetime import datetime, timezone
 from hashlib import sha512
 from typing import Any, Dict, List
@@ -184,12 +183,14 @@ async def receive_measurement(
             Metrics.COMPARE_CC_FAILURE.inc()
 
     # Use exponential back off with jitter between retries
+    client = request.app.state.fastpath_client
     with Metrics.SEND_FASTPATH_TIMING.time():
         try:
             url = f"{settings.fastpath_url}/{msmt_uid}"
 
-            resp = await run_in_threadpool(requests.post, url, data=data)
-            resp.raise_for_status()
+            resp = await run_in_threadpool(client.post, url, data=data)
+            with resp:
+                resp.raise_for_status()
             Metrics.SEND_FASTPATH_CNT.labels(status="ok").inc()
             return ReceiveMeasurementResponse(measurement_uid=msmt_uid)
 

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -2,7 +2,6 @@ import asyncio
 import io
 import logging
 import random
-import requests
 import time
 from enum import Enum
 from datetime import datetime, timedelta, timezone
@@ -987,13 +986,15 @@ async def submit_measurement(
 
     # Use exponential back off with jitter between retries to avoid choking the fastpath server
     # with many retries at the same time when there's a temporary issue
+    client = request.app.state.fastpath_client
     N_RETRIES = 3
     for t in range(N_RETRIES):
         try:
             url = f"{settings.fastpath_url}/{msmt_uid}"
 
-            resp = await run_in_threadpool(requests.post, url, data=data)
-            resp.raise_for_status()
+            resp = await run_in_threadpool(client.post, url, data=data)
+            with resp:
+                resp.raise_for_status()
 
             return SubmitMeasurementResponse(
                 measurement_uid=msmt_uid,

--- a/ooniapi/services/ooniprobe/src/ooniprobe/utils.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/utils.py
@@ -48,14 +48,16 @@ class OpenVPNEndpoint(TypedDict):
 
 def fetch_riseup_ca() -> str:
     r = requests.get(RISEUP_CA_URL)
-    r.raise_for_status()
-    return r.text.strip()
+    with r:
+        r.raise_for_status()
+        return r.text.strip()
 
 
 def fetch_riseup_cert() -> str:
     r = requests.get(RISEUP_CERT_URL)
-    r.raise_for_status()
-    return r.text.strip()
+    with r:
+        r.raise_for_status()
+        return r.text.strip()
 
 
 def fetch_openvpn_config() -> OpenVPNConfig:


### PR DESCRIPTION
Use requests.Session so that connections are re-used. Also, use context manager for each response to ensure it is closed correctly even if an exception is raised or if the body is not read

fixes #1177