### PR TITLE
Reset is_verified on submit

### DIFF
--- a/ooniapi/services/ooniprobe/src/ooniprobe/metrics.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/metrics.py
@@ -65,6 +65,11 @@ class Metrics:
         "How long it took to read the measurement body",
     )
 
+    NORMALIZE_BODY_TIMING = Histogram(
+        "measurement_normalize_body_seconds",
+        "How long it took to parse and normalize the measurement body",
+    )
+
     SEND_FASTPATH_TIMING = Histogram(
         "measurement_fastpath_send_seconds",
         "How long it took to post the measurement to the fastpath",

--- a/ooniapi/services/ooniprobe/src/ooniprobe/metrics.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/metrics.py
@@ -65,9 +65,14 @@ class Metrics:
         "How long it took to read the measurement body",
     )
 
-    NORMALIZE_BODY_TIMING = Histogram(
-        "measurement_normalize_body_seconds",
-        "How long it took to parse and normalize the measurement body",
+    DESERIALIZE_BODY_TIMING = Histogram(
+        "measurement_deserialize_body_seconds",
+        "How long it took to deserialize the measurement body from JSON",
+    )
+
+    SERIALIZE_BODY_TIMING = Histogram(
+        "measurement_serialize_body_seconds",
+        "How long it took to serialize the measurement body to JSON",
     )
 
     SEND_FASTPATH_TIMING = Histogram(

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
@@ -157,7 +157,7 @@ async def receive_measurement(
             error("Incorrect format")
 
     try:
-        data = await run_in_threadpool(_ensure_unverified_flag, data)
+        data = await run_in_threadpool(_set_unverified_flag, data)
     except Exception as e:
         log.info(f"Failed to parse and measurement body. Error: {e}")
         Metrics.BAD_MEASUREMENTS_CNT.labels(reason="bad_json").inc()
@@ -225,7 +225,7 @@ async def receive_measurement(
             return empty_measurement
 
 
-def _ensure_unverified_flag(data: bytes) -> bytes:
+def _set_unverified_flag(data: bytes) -> bytes:
     with Metrics.DESERIALIZE_BODY_TIMING.time():
         measurement = ujson.loads(data)
     measurement["is_verified"] = "u"

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
@@ -166,6 +166,7 @@ async def receive_measurement(
     # Write the whole body of the measurement in a directory based on a 1-hour
     # time window
     now = datetime.now(timezone.utc)
+    # Hash MUST be computed after adding extra fields
     h = sha512(data).hexdigest()[:16]
     ts = now.strftime("%Y%m%d%H%M%S.%f")
 

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
@@ -158,7 +158,8 @@ async def receive_measurement(
     try:
         data = await run_in_threadpool(_set_unverified_flag, data)
     except Exception as e:
-        log.info(f"Failed to parse and measurement body. Error: {e}")
+        log.info("Failed to parse and modify measurement body")
+        log.exception(e)
         Metrics.BAD_MEASUREMENTS_CNT.labels(reason="bad_json").inc()
         error("Incorrect format")
 

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
@@ -1,11 +1,10 @@
-import asyncio
 import io
 import logging
-import random
 from datetime import datetime, timezone
 from hashlib import sha512
 from typing import Any, Dict, List
 
+import ujson
 import zstd
 from fastapi import APIRouter, Header, Request, Response
 from pydantic import Field
@@ -15,7 +14,7 @@ from ..common.dependencies import ClickhouseDep
 from ..common.metrics import timer
 from ..common.routers import BaseModel
 from ..common.utils import setnocacheresponse
-from ..dependencies import ASNReaderDep, CCReaderDep, S3ClientDep, SettingsDep
+from ..dependencies import ASNReaderDep, CCReaderDep, SettingsDep
 from ..metrics import Metrics
 from ..utils import (
     compare_probe_msmt_cc_asn,
@@ -156,6 +155,14 @@ async def receive_measurement(
             Metrics.BAD_MEASUREMENTS_CNT.labels(reason="zstd_fail").inc()
             error("Incorrect format")
 
+    with Metrics.NORMALIZE_BODY_TIMING.time():
+        try:
+            data = await run_in_threadpool(_ensure_unverified_flag, data)
+        except Exception as e:
+            log.info(f"Failed to parse and measurement body. Error: {e}")
+            Metrics.BAD_MEASUREMENTS_CNT.labels(reason="bad_json").inc()
+            error("Incorrect format")
+
     # Write the whole body of the measurement in a directory based on a 1-hour
     # time window
     now = datetime.now(timezone.utc)
@@ -222,6 +229,12 @@ async def receive_measurement(
             log.exception("Unable to upload measurement to s3")
             Metrics.SEND_S3_CNT.labels(status="fail").inc()
             return empty_measurement
+
+
+def _ensure_unverified_flag(data: bytes) -> bytes:
+    measurement = ujson.loads(data)
+    measurement["is_verified"] = "u"
+    return ujson.dumps(measurement).encode("utf-8")
 
 
 @timer(name="close_report")

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
@@ -155,13 +155,12 @@ async def receive_measurement(
             Metrics.BAD_MEASUREMENTS_CNT.labels(reason="zstd_fail").inc()
             error("Incorrect format")
 
-    with Metrics.NORMALIZE_BODY_TIMING.time():
-        try:
-            data = await run_in_threadpool(_ensure_unverified_flag, data)
-        except Exception as e:
-            log.info(f"Failed to parse and measurement body. Error: {e}")
-            Metrics.BAD_MEASUREMENTS_CNT.labels(reason="bad_json").inc()
-            error("Incorrect format")
+    try:
+        data = await run_in_threadpool(_ensure_unverified_flag, data)
+    except Exception as e:
+        log.info(f"Failed to parse and measurement body. Error: {e}")
+        Metrics.BAD_MEASUREMENTS_CNT.labels(reason="bad_json").inc()
+        error("Incorrect format")
 
     # Write the whole body of the measurement in a directory based on a 1-hour
     # time window
@@ -232,9 +231,11 @@ async def receive_measurement(
 
 
 def _ensure_unverified_flag(data: bytes) -> bytes:
-    measurement = ujson.loads(data)
+    with Metrics.DESERIALIZE_BODY_TIMING.time():
+        measurement = ujson.loads(data)
     measurement["is_verified"] = "u"
-    return ujson.dumps(measurement).encode("utf-8")
+    with Metrics.SERIALIZE_BODY_TIMING.time():
+        return ujson.dumps(measurement).encode("utf-8")
 
 
 @timer(name="close_report")

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -962,6 +962,7 @@ async def submit_measurement(
     # Write the whole body of the measurement in a directory based on a 1-hour
     # time window
     now = datetime.now(timezone.utc)
+    # Hash MUST be computed after adding extra fields
     h = sha512(data_bin).hexdigest()[:16]
     ts = now.strftime("%Y%m%d%H%M%S.%f")
 

--- a/ooniapi/services/ooniprobe/tests/integ/test_reports.py
+++ b/ooniapi/services/ooniprobe/tests/integ/test_reports.py
@@ -1,6 +1,8 @@
 import json
 import zstd
 import pytest
+from hashlib import sha512
+import ujson
 
 def postj(client, url, json):
     response = client.post(url, json=json)
@@ -77,9 +79,16 @@ async def test_collector_upload_msmt_valid(client):
 @pytest.mark.asyncio
 async def test_collector_upload_msmt_valid_zstd(client):
     rid = "20230101T000000Z_integtest_IT_1_n1_integtest0000000"
-    msmt = json.dumps(dict(test_keys={})).encode()
-    zmsmt = zstd.compress(msmt)
+    msmt_payload = {"test_keys": {}}
+    zmsmt = zstd.compress(json.dumps(msmt_payload).encode())
     headers = [("Content-Encoding", "zstd")]
     c = post(client, f"/report/{rid}", zmsmt, headers=headers)
     assert len(c) == 1
-    assert c['measurement_uid'].endswith("_IT_integtest_50be3cd5406bca65"), c
+
+    expected_hash = _get_hash_of({"test_keys": {}, "is_verified": "u"})
+    assert c["measurement_uid"].endswith(f"_IT_integtest_{expected_hash}"), c
+
+def _get_hash_of(msmt : dict) -> str:
+    # separators make this consistent with what the server receives
+    d = ujson.dumps(msmt).encode()
+    return sha512(d).hexdigest()[:16]

--- a/ooniapi/services/ooniprobe/tests/integ/test_reports.py
+++ b/ooniapi/services/ooniprobe/tests/integ/test_reports.py
@@ -3,6 +3,7 @@ import zstd
 import pytest
 from hashlib import sha512
 import ujson
+import copy
 
 def postj(client, url, json):
     response = client.post(url, json=json)
@@ -68,9 +69,10 @@ async def test_collector_upload_msmt_valid(client):
     }
     assert len(rid) == 61, rid
 
-    msmt = dict(test_keys={})
-    c = postj(client, f"/report/{rid}", {"format":"json", "content":msmt}) # unsure about this merge
-    assert c['measurement_uid'].endswith("_IE_webconnectivity_e7889aeba0b36729"), c
+    upload_payload = {"format": "json", "content": {"test_keys": {}}}
+    c = postj(client, f"/report/{rid}", upload_payload)
+    expected_hash = _get_hash_of(upload_payload)
+    assert c["measurement_uid"].endswith(f"_IE_webconnectivity_{expected_hash}"), c
 
     c = postj(client, f"/report/{rid}/close", json={})
     assert c == {}, c
@@ -85,10 +87,11 @@ async def test_collector_upload_msmt_valid_zstd(client):
     c = post(client, f"/report/{rid}", zmsmt, headers=headers)
     assert len(c) == 1
 
-    expected_hash = _get_hash_of({"test_keys": {}, "is_verified": "u"})
+    expected_hash = _get_hash_of(msmt_payload)
     assert c["measurement_uid"].endswith(f"_IT_integtest_{expected_hash}"), c
 
-def _get_hash_of(msmt : dict) -> str:
-    # separators make this consistent with what the server receives
-    d = ujson.dumps(msmt).encode()
+def _get_hash_of(msmt: dict) -> str:
+    payload = copy.deepcopy(msmt)
+    payload["is_verified"] = "u"
+    d = ujson.dumps(payload).encode()
     return sha512(d).hexdigest()[:16]


### PR DESCRIPTION
This PR will reset the `is_verified` field on the measurement to a default value before storing it to DB in the legacy submission path 

Closes https://github.com/ooni/backend/issues/1165