### PR TITLE
Point smoketests to version instead of health

### DIFF
--- a/ooniapi/services/ooniauth/scripts/docker-smoketest.sh
+++ b/ooniapi/services/ooniauth/scripts/docker-smoketest.sh
@@ -33,10 +33,10 @@ docker run \
 trap cleanup INT TERM EXIT
 
 sleep 2
-response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT/health)
+response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT/version)
 if [ "${response}" -eq 200 ]; then
-  echo "Smoke test passed: Received 200 OK from /health endpoint."
+  echo "Smoke test passed: Received 200 OK from /version endpoint."
 else
-  echo "Smoke test failed: Did not receive 200 OK from /health endpoint. Received: $response"
+  echo "Smoke test failed: Did not receive 200 OK from /version endpoint. Received: $response"
   exit 1
 fi

--- a/ooniapi/services/oonifindings/scripts/docker-smoketest.sh
+++ b/ooniapi/services/oonifindings/scripts/docker-smoketest.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 h
 
 set -ex
@@ -25,10 +27,10 @@ docker run -d --name $CONTAINER_NAME -p $PORT:80 ${IMAGE}
 trap cleanup INT TERM EXIT
 
 sleep 2
-response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT/health)
+response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT/version)
 if [ "${response}" -eq 200 ]; then
-  echo "Smoke test passed: Received 200 OK from /health endpoint."
+  echo "Smoke test passed: Received 200 OK from /version endpoint."
 else
-  echo "Smoke test failed: Did not receive 200 OK from /health endpoint. Received: $response"
+  echo "Smoke test failed: Did not receive 200 OK from /version endpoint. Received: $response"
   exit 1
 fi

--- a/ooniapi/services/oonimeasurements/scripts/docker-smoketest.sh
+++ b/ooniapi/services/oonimeasurements/scripts/docker-smoketest.sh
@@ -25,10 +25,10 @@ docker run -d --env VALKEY_URL=memory --name $CONTAINER_NAME -p $PORT:80 ${IMAGE
 trap cleanup INT TERM EXIT
 
 sleep 2
-response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT/health)
+response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT/version)
 if [ "${response}" -eq 200 ]; then
-  echo "Smoke test passed: Received 200 OK from /health endpoint."
+  echo "Smoke test passed: Received 200 OK from /version endpoint."
 else
-  echo "Smoke test failed: Did not receive 200 OK from /health endpoint. Received: $response"
+  echo "Smoke test failed: Did not receive 200 OK from /version endpoint. Received: $response"
   exit 1
 fi

--- a/ooniapi/services/ooniprobe/scripts/docker-smoketest.sh
+++ b/ooniapi/services/ooniprobe/scripts/docker-smoketest.sh
@@ -25,10 +25,10 @@ docker run -d --name $CONTAINER_NAME -p $PORT:80 ${IMAGE}
 trap cleanup INT TERM EXIT
 
 sleep 4
-response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT/health)
+response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT/version)
 if [ "${response}" -eq 200 ]; then
-  echo "Smoke test passed: Received 200 OK from /health endpoint."
+  echo "Smoke test passed: Received 200 OK from /version endpoint."
 else
-  echo "Smoke test failed: Did not receive 200 OK from /health endpoint. Received: $response"
+  echo "Smoke test failed: Did not receive 200 OK from /version endpoint. Received: $response"
   exit 1
 fi

--- a/ooniapi/services/oonirun/scripts/docker-smoketest.sh
+++ b/ooniapi/services/oonirun/scripts/docker-smoketest.sh
@@ -25,10 +25,10 @@ docker run -d --name $CONTAINER_NAME -p $PORT:80 ${IMAGE}
 trap cleanup INT TERM EXIT
 
 sleep 2
-response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT/health)
+response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT/version)
 if [ "${response}" -eq 200 ]; then
-  echo "Smoke test passed: Received 200 OK from /health endpoint."
+  echo "Smoke test passed: Received 200 OK from /version endpoint."
 else
-  echo "Smoke test failed: Did not receive 200 OK from /health endpoint. Received: $response"
+  echo "Smoke test failed: Did not receive 200 OK from /version endpoint. Received: $response"
   exit 1
 fi

--- a/ooniapi/services/testlists/scripts/docker-smoketest.sh
+++ b/ooniapi/services/testlists/scripts/docker-smoketest.sh
@@ -25,10 +25,10 @@ docker run -d --name $CONTAINER_NAME -p $PORT:80 ${IMAGE}
 trap cleanup INT TERM EXIT
 
 sleep 2
-response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT/health)
+response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT/version)
 if [ "${response}" -eq 200 ]; then
-  echo "Smoke test passed: Received 200 OK from /health endpoint."
+  echo "Smoke test passed: Received 200 OK from /version endpoint."
 else
-  echo "Smoke test failed: Did not receive 200 OK from /health endpoint. Received: $response"
+  echo "Smoke test failed: Did not receive 200 OK from /version endpoint. Received: $response"
   exit 1
 fi


### PR DESCRIPTION
This PR changes the smoketest to point to `/version` instead of `/health` 

The `/health` endpoint evolved a bit to involve checking health of services, configuration consistency and preconditions. So it depends on several external things to work properly (the manifest in s3, valkey, clickhouse) so now it's not really fit for a smoke test. 

So instead we will use the `/version` endpoint, which is a good proxy to check if the service is able to start up

closes #1183 