### PR TITLE
Add fastpath fallback

### DIFF
--- a/ooniapi/common/src/common/config.py
+++ b/ooniapi/common/src/common/config.py
@@ -1,7 +1,6 @@
 from typing import Dict, List
 
 from pydantic import Field
-from pydantic.fields import Deprecated
 from pydantic_settings import BaseSettings
 
 
@@ -47,16 +46,11 @@ class Settings(BaseSettings):
     geoip_db_dir: str = "/var/lib/ooni/geoip"
     # -- < Ooniprobe only > -------------------------------------------------------------
     msmt_spool_dir: str = ""
-    fastpath_url: str = Field(
-        default="",
-        deprecated=Deprecated(
-            "This will be replaced by the `fastpath_urls` field in the near future"
-        ),
-    )  # example: http://123.123.123.123:8472
     fastpath_urls: List[str] = Field(
         description="List of fastpath instances to send measurements to",
         default_factory=list,
-    )
+    ) # example: [http://123.123.123.123:8472]
+
     failed_reports_bucket: str = (
         ""  # for uploading reports that couldn't be sent to fastpath
     )

--- a/ooniapi/common/src/common/config.py
+++ b/ooniapi/common/src/common/config.py
@@ -1,6 +1,7 @@
 from typing import Dict, List
 
 from pydantic import Field
+from pydantic.fields import Deprecated
 from pydantic_settings import BaseSettings
 
 
@@ -46,7 +47,16 @@ class Settings(BaseSettings):
     geoip_db_dir: str = "/var/lib/ooni/geoip"
     # -- < Ooniprobe only > -------------------------------------------------------------
     msmt_spool_dir: str = ""
-    fastpath_url: str = ""  # example: http://123.123.123.123:8472
+    fastpath_url: str = Field(
+        default="",
+        deprecated=Deprecated(
+            "This will be replaced by the `fastpath_urls` field in the near future"
+        ),
+    )  # example: http://123.123.123.123:8472
+    fastpath_urls: List[str] = Field(
+        description="List of fastpath instances to send measurements to",
+        default_factory=list,
+    )
     failed_reports_bucket: str = (
         ""  # for uploading reports that couldn't be sent to fastpath
     )

--- a/ooniapi/services/ooniprobe/src/ooniprobe/main.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/main.py
@@ -126,13 +126,17 @@ async def health(
         errors.append("clickhouse_error")
         log.error(e)
 
-    try:
-        resp = await run_in_threadpool(app.state.fastpath_client.get, settings.fastpath_url)
-        with resp:
-            resp.raise_for_status()
-    except Exception as exc:
-        log.error(str(exc))
-        errors.append("fastpath_connection_error")
+    fastpath_urls = [settings.fastpath_url, *settings.fastpath_urls] if settings.fastpath_url else settings.fastpath_urls
+
+    for fastpath_url in fastpath_urls:
+        try:
+            resp = await run_in_threadpool(app.state.fastpath_client.get, settings.fastpath_url)
+            with resp:
+                resp.raise_for_status()
+        except Exception as exc:
+            log.error(f"Unable to connect with fastpath '{fastpath_url}. Error: {exc}'")
+            errors.append("fastpath_connection_error")
+
 
     try:
         db.query(models.OONIProbeVPNProvider).limit(1).all()

--- a/ooniapi/services/ooniprobe/src/ooniprobe/main.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/main.py
@@ -126,11 +126,9 @@ async def health(
         errors.append("clickhouse_error")
         log.error(e)
 
-    fastpath_urls = [settings.fastpath_url, *settings.fastpath_urls] if settings.fastpath_url else settings.fastpath_urls
-
-    for fastpath_url in fastpath_urls:
+    for fastpath_url in settings.fastpath_urls:
         try:
-            resp = await run_in_threadpool(app.state.fastpath_client.get, settings.fastpath_url)
+            resp = await run_in_threadpool(app.state.fastpath_client.get, fastpath_url)
             with resp:
                 resp.raise_for_status()
         except Exception as exc:

--- a/ooniapi/services/ooniprobe/src/ooniprobe/main.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/main.py
@@ -132,7 +132,7 @@ async def health(
             with resp:
                 resp.raise_for_status()
         except Exception as exc:
-            log.error(f"Unable to connect with fastpath '{fastpath_url}. Error: {exc}'")
+            log.error(f"Unable to connect with fastpath '{fastpath_url}'. Error: {exc}")
             errors.append("fastpath_connection_error")
 
 

--- a/ooniapi/services/ooniprobe/src/ooniprobe/metrics.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/metrics.py
@@ -88,7 +88,7 @@ class Metrics:
     SEND_FASTPATH_CNT = Counter(
         "measurement_fastpath_send_count",
         "How many times ooniprobe failed to send a measurement to fastpath",
-        labelnames=["status"],
+        labelnames=["status", "instance"],
     )
 
     SEND_S3_CNT = Counter(

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
@@ -197,7 +197,8 @@ async def receive_measurement(
                     f"[{i + 1} / {len(fastpath_urls)}] Unable to send measurement to fastpath "
                     f"({fastpath_url}): {e}"
                 )
-            Metrics.SEND_FASTPATH_CNT.labels(status="fail", instance="NA").inc()
+
+    Metrics.SEND_FASTPATH_CNT.labels(status="fail", instance="NA").inc()
 
     if success:
         # Geoip anomaly detection runs only when the measurement was successfully

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
@@ -191,6 +191,7 @@ async def receive_measurement(
                     instance=fastpath_url
                     ).inc()
                 success = True
+                break
 
             except Exception as e:
                 log.exception(

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
@@ -176,7 +176,7 @@ async def receive_measurement(
     Metrics.MSMNT_RECEIVED_CNT.inc()
 
     client = request.app.state.fastpath_client
-    fastpath_urls = [*settings.fastpath_urls, settings.fastpath_url] if settings.fastpath_url else settings.fastpath_urls
+    fastpath_urls = settings.fastpath_urls
     success = False
     for (i, fastpath_url) in enumerate(fastpath_urls):
         with Metrics.SEND_FASTPATH_TIMING.time():

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
@@ -176,20 +176,28 @@ async def receive_measurement(
     Metrics.MSMNT_RECEIVED_CNT.inc()
 
     client = request.app.state.fastpath_client
+    fastpath_urls = [*settings.fastpath_urls, settings.fastpath_url] if settings.fastpath_url else settings.fastpath_urls
     success = False
-    with Metrics.SEND_FASTPATH_TIMING.time():
-        try:
-            url = f"{settings.fastpath_url}/{msmt_uid}"
+    for (i, fastpath_url) in enumerate(fastpath_urls):
+        with Metrics.SEND_FASTPATH_TIMING.time():
+            try:
+                url = f"{fastpath_url}/{msmt_uid}"
 
-            resp = await run_in_threadpool(client.post, url, data=data)
-            with resp:
-                resp.raise_for_status()
-            Metrics.SEND_FASTPATH_CNT.labels(status="ok").inc()
-            success = True
+                resp = await run_in_threadpool(client.post, url, data=data)
+                with resp:
+                    resp.raise_for_status()
+                Metrics.SEND_FASTPATH_CNT.labels(
+                    status="ok",
+                    instance=fastpath_url
+                    ).inc()
+                success = True
 
-        except Exception as e:
-            log.exception(f"Unable to send measurement to fastpath ({settings.fastpath_url}): {e}")
-            Metrics.SEND_FASTPATH_CNT.labels(status="fail").inc()
+            except Exception as e:
+                log.exception(
+                    f"[{i + 1} / {len(fastpath_urls)}] Unable to send measurement to fastpath "
+                    f"({fastpath_url}): {e}"
+                )
+            Metrics.SEND_FASTPATH_CNT.labels(status="fail", instance="NA").inc()
 
     if success:
         # Geoip anomaly detection runs only when the measurement was successfully

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -975,27 +975,29 @@ async def submit_measurement(
     # Use exponential back off with jitter between retries to avoid choking the fastpath server
     # with many retries at the same time when there's a temporary issue
     client = request.app.state.fastpath_client
-    N_RETRIES = 3
     success = False
-    with Metrics.SEND_FASTPATH_TIMING.time():
-        for t in range(N_RETRIES):
+    fastpath_urls = [*settings.fastpath_urls, settings.fastpath_url] if settings.fastpath_url else settings.fastpath_urls
+    for (i, fastpath_url) in enumerate(fastpath_urls):
+        with Metrics.SEND_FASTPATH_TIMING.time():
             try:
-                url = f"{settings.fastpath_url}/{msmt_uid}"
+                url = f"{fastpath_url}/{msmt_uid}"
 
                 resp = await run_in_threadpool(client.post, url, data=data_bin)
                 with resp:
                     resp.raise_for_status()
-
-                Metrics.SEND_FASTPATH_CNT.labels(status="ok").inc()
+                Metrics.SEND_FASTPATH_CNT.labels(
+                    status="ok",
+                    instance=fastpath_url
+                    ).inc()
                 success = True
-                break
 
-            except Exception as exc:
-                log.error(
-                    f"[Try {t + 1}/{N_RETRIES}] Error trying to send measurement to the fastpath ({settings.fastpath_url}). Error: {exc}"
+            except Exception as e:
+                log.exception(
+                    f"[{i + 1} / {len(fastpath_urls)}] Unable to send measurement to fastpath "
+                    f"({fastpath_url}): {e}"
                 )
-                sleep_time = random.uniform(0, min(3, 0.3 * 2**t))
-                await asyncio.sleep(sleep_time)
+
+    Metrics.SEND_FASTPATH_CNT.labels(status="fail", instance="NA").inc()
 
     if success:
         # Geoip anomaly detection runs only when the measurement was successfully

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -976,7 +976,7 @@ async def submit_measurement(
     # with many retries at the same time when there's a temporary issue
     client = request.app.state.fastpath_client
     success = False
-    fastpath_urls = [*settings.fastpath_urls, settings.fastpath_url] if settings.fastpath_url else settings.fastpath_urls
+    fastpath_urls = settings.fastpath_urls
     for (i, fastpath_url) in enumerate(fastpath_urls):
         with Metrics.SEND_FASTPATH_TIMING.time():
             try:

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -990,6 +990,7 @@ async def submit_measurement(
                     instance=fastpath_url
                     ).inc()
                 success = True
+                break
 
             except Exception as e:
                 log.exception(

--- a/ooniapi/services/ooniprobe/tests/conftest.py
+++ b/ooniapi/services/ooniprobe/tests/conftest.py
@@ -181,7 +181,7 @@ def test_settings(
         clickhouse_url=clickhouse_server,
         geoip_db_dir=geoip_db_dir,
         collector_id="1",
-        fastpath_url=fastpath_server,
+        fastpath_urls=[fastpath_server],
         anonc_manifest_bucket="test-bucket",
         anonc_manifest_file="manifest.json",
         anonc_secret_key=secret_key,
@@ -351,7 +351,6 @@ async def client_with_mocked_fastpath(
 
     settings = test_settings().model_copy(
         update={
-            "fastpath_url": "",
             "fastpath_urls": [fail_url, success_url],
         }
     )
@@ -385,7 +384,6 @@ async def client_with_two_working_fastpaths(
 
     settings = test_settings().model_copy(
         update={
-            "fastpath_url": "",
             "fastpath_urls": [first_url, second_url],
         }
     )

--- a/ooniapi/services/ooniprobe/tests/conftest.py
+++ b/ooniapi/services/ooniprobe/tests/conftest.py
@@ -367,3 +367,37 @@ async def client_with_mocked_fastpath(
         with TestClient(app) as client:
             app.state.fastpath_client = mock_fastpath
             yield client, mock_fastpath, success_url
+
+
+@pytest_asyncio.fixture
+async def client_with_two_working_fastpaths(
+    clickhouse_server, test_settings, geoip_db_dir, test_creds
+):
+    """
+    Client variant to test successful fastpath submissions with two healthy fastpath instances
+
+    Yields `(client, mock_fastpath, first_url, second_url)`.
+    """
+    first_url = "http://fastpath-a.ooni/good"
+    second_url = "http://fastpath-b.ooni/good"
+
+    _, public_key = test_creds
+
+    settings = test_settings().model_copy(
+        update={
+            "fastpath_url": "",
+            "fastpath_urls": [first_url, second_url],
+        }
+    )
+    app.dependency_overrides[get_settings] = lambda: settings
+    app.dependency_overrides[get_s3_client] = get_s3_client_mock
+    app.dependency_overrides[get_tor_targets_from_s3] = get_tor_targets_from_s3_mock
+    app.dependency_overrides[get_psiphon_config_from_s3] = get_psiphon_config_from_s3_mock
+    app.dependency_overrides[_get_manifest] = make_manifest_mock_fn(public_key)
+    try_update(geoip_db_dir)
+
+    mock_fastpath = MockFastpathClient()
+    async with lifespan(app, settings, repeating_tasks_active=False):
+        with TestClient(app) as client:
+            app.state.fastpath_client = mock_fastpath
+            yield client, mock_fastpath, first_url, second_url

--- a/ooniapi/services/ooniprobe/tests/conftest.py
+++ b/ooniapi/services/ooniprobe/tests/conftest.py
@@ -8,6 +8,7 @@ from urllib.request import urlopen
 
 import ooniauth_py
 import pytest
+import requests
 import ujson
 from clickhouse_driver import Client as ClickhouseClient
 from fastapi.testclient import TestClient
@@ -289,3 +290,80 @@ def load_url_priorities(clickhouse_db: ClickhouseClient):
 @pytest.fixture(scope="function")
 def client_with_original_manifest(client):
     return setup_user(client)
+
+
+class MockFastpathResponse:
+    """
+    Mocked fastpath response to emulate fastpath client responses
+    """
+
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"HTTP {self.status_code}")
+
+
+class MockFastpathClient:
+    """
+    This mocked fastpath client that responds with error for some paths, and success with other
+    paths.
+
+    Used for testing fastpath responses
+    """
+
+    def __init__(self, success_url_prefix: str = "/good/"):
+        self.success_url_prefix = success_url_prefix
+        self.uploads: dict[str, bytes] = {}
+
+    def post(self, url: str, data: bytes = b"", **kwargs):
+        if self.success_url_prefix in url:
+            self.uploads[url] = data
+            return MockFastpathResponse(200)
+        return MockFastpathResponse(502)
+
+    def close(self):
+        # called by the app lifespan on shutdown
+        pass
+
+
+@pytest_asyncio.fixture
+async def client_with_mocked_fastpath(
+    clickhouse_server, test_settings, geoip_db_dir, test_creds
+):
+    """
+    Client variant to test fastpath behaviour, see the mocked fastpath client
+    above.
+
+    Yields `(client, mock_fastpath, success_url)`.
+    """
+    fail_url = "http://fastpath.ooni/bad"
+    success_url = "http://fastpath.ooni/good"
+
+    _, public_key = test_creds
+
+    settings = test_settings().model_copy(
+        update={
+            "fastpath_url": "",
+            "fastpath_urls": [fail_url, success_url],
+        }
+    )
+    app.dependency_overrides[get_settings] = lambda: settings
+    app.dependency_overrides[get_s3_client] = get_s3_client_mock
+    app.dependency_overrides[get_tor_targets_from_s3] = get_tor_targets_from_s3_mock
+    app.dependency_overrides[get_psiphon_config_from_s3] = get_psiphon_config_from_s3_mock
+    app.dependency_overrides[_get_manifest] = make_manifest_mock_fn(public_key)
+    try_update(geoip_db_dir)
+
+    mock_fastpath = MockFastpathClient()
+    async with lifespan(app, settings, repeating_tasks_active=False):
+        with TestClient(app) as client:
+            app.state.fastpath_client = mock_fastpath
+            yield client, mock_fastpath, success_url

--- a/ooniapi/services/ooniprobe/tests/integ/test_reports.py
+++ b/ooniapi/services/ooniprobe/tests/integ/test_reports.py
@@ -125,3 +125,38 @@ async def test_fastpath_fallback(client_with_mocked_fastpath):
     stored = ujson.loads(mock_fastpath.uploads[expected_url])
     assert get_msmt_hash(stored) == expected_hash
     assert stored["is_verified"] == "u"
+
+
+@pytest.mark.asyncio
+async def test_fastpath_only_submits_once_on_success(client_with_two_working_fastpaths):
+    """
+    When the first fastpath URL succeeds, the receiver should stop iterating
+    """
+    client, mock_fastpath, first_url, second_url = client_with_two_working_fastpaths
+
+    rid = "20230101T000000Z_integtest_IT_1_n1_integtest0000000"
+    msmt_payload = {
+        "format": "json",
+        "content": {
+            "test_keys": {},
+            "annotations": {"platform": "test_platform"},
+            "software_name": "test_software",
+            "software_version": "0.0.0",
+        },
+    }
+    resp = client.post(f"/report/{rid}", json=msmt_payload)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    msmt_uid = body.get("measurement_uid")
+    assert msmt_uid, body
+
+    # Sanity-check the bytes that were forwarded to the fastpath
+    expected_hash = get_msmt_hash(msmt_payload)
+    assert msmt_uid.endswith(f"_IT_integtest_{expected_hash}"), msmt_uid
+
+    # Only the first fastpath URL should have received the measurement
+    expected_url = f"{first_url}/{msmt_uid}"
+    assert list(mock_fastpath.uploads.keys()) == [expected_url], (
+        "measurement should be forwarded to the first fastpath URL only, "
+        f"got {list(mock_fastpath.uploads.keys())}"
+    )

--- a/ooniapi/services/ooniprobe/tests/integ/test_reports.py
+++ b/ooniapi/services/ooniprobe/tests/integ/test_reports.py
@@ -1,7 +1,6 @@
 import json
 import zstd
 import pytest
-from hashlib import sha512
 import ujson
 
 from ..utils import get_msmt_hash
@@ -123,6 +122,6 @@ async def test_fastpath_fallback(client_with_mocked_fastpath):
     expected_url = f"{success_url}/{msmt_uid}"
     assert list(mock_fastpath.uploads.keys()) == [expected_url]
 
-    stored = mock_fastpath.uploads[expected_url]
-    assert sha512(stored).hexdigest()[:16] == expected_hash
-    assert ujson.loads(stored)["is_verified"] == "u"
+    stored = ujson.loads(mock_fastpath.uploads[expected_url])
+    assert get_msmt_hash(stored) == expected_hash
+    assert stored["is_verified"] == "u"

--- a/ooniapi/services/ooniprobe/tests/integ/test_reports.py
+++ b/ooniapi/services/ooniprobe/tests/integ/test_reports.py
@@ -3,7 +3,8 @@ import zstd
 import pytest
 from hashlib import sha512
 import ujson
-import copy
+
+from ..utils import get_msmt_hash
 
 
 def postj(client, url, json):
@@ -72,7 +73,7 @@ async def test_collector_upload_msmt_valid(client):
 
     upload_payload = {"format": "json", "content": {"test_keys": {}}}
     c = postj(client, f"/report/{rid}", upload_payload)
-    expected_hash = _get_hash_of(upload_payload)
+    expected_hash = get_msmt_hash(upload_payload)
     assert c["measurement_uid"].endswith(f"_IE_webconnectivity_{expected_hash}"), c
 
     c = postj(client, f"/report/{rid}/close", json={})
@@ -88,11 +89,11 @@ async def test_collector_upload_msmt_valid_zstd(client):
     c = post(client, f"/report/{rid}", zmsmt, headers=headers)
     assert len(c) == 1
 
-    expected_hash = _get_hash_of(msmt_payload)
+    expected_hash = get_msmt_hash(msmt_payload)
     assert c["measurement_uid"].endswith(f"_IT_integtest_{expected_hash}"), c
 
 @pytest.mark.asyncio
-async def test_collector_upload_msmt_fastpath_fallback(client_with_mocked_fastpath):
+async def test_fastpath_fallback(client_with_mocked_fastpath):
     """When the first fastpath URL fails, the second one in the list
     should still receive the measurement.
     """
@@ -115,7 +116,7 @@ async def test_collector_upload_msmt_fastpath_fallback(client_with_mocked_fastpa
     msmt_uid = body["measurement_uid"]
     assert msmt_uid, body
 
-    expected_hash = _get_hash_of(msmt_payload)
+    expected_hash = get_msmt_hash(msmt_payload)
     assert msmt_uid.endswith(f"_IT_integtest_{expected_hash}"), msmt_uid
 
     # check saved data
@@ -125,9 +126,3 @@ async def test_collector_upload_msmt_fastpath_fallback(client_with_mocked_fastpa
     stored = mock_fastpath.uploads[expected_url]
     assert sha512(stored).hexdigest()[:16] == expected_hash
     assert ujson.loads(stored)["is_verified"] == "u"
-
-def _get_hash_of(msmt: dict) -> str:
-    payload = copy.deepcopy(msmt)
-    payload["is_verified"] = "u"
-    d = ujson.dumps(payload).encode()
-    return sha512(d).hexdigest()[:16]

--- a/ooniapi/services/ooniprobe/tests/integ/test_reports.py
+++ b/ooniapi/services/ooniprobe/tests/integ/test_reports.py
@@ -5,6 +5,7 @@ from hashlib import sha512
 import ujson
 import copy
 
+
 def postj(client, url, json):
     response = client.post(url, json=json)
     assert response.status_code == 200, response.json()
@@ -89,6 +90,41 @@ async def test_collector_upload_msmt_valid_zstd(client):
 
     expected_hash = _get_hash_of(msmt_payload)
     assert c["measurement_uid"].endswith(f"_IT_integtest_{expected_hash}"), c
+
+@pytest.mark.asyncio
+async def test_collector_upload_msmt_fastpath_fallback(client_with_mocked_fastpath):
+    """When the first fastpath URL fails, the second one in the list
+    should still receive the measurement.
+    """
+    client, mock_fastpath, success_url = client_with_mocked_fastpath
+
+    rid = "20230101T000000Z_integtest_IT_1_n1_integtest0000000"
+    msmt_payload = {
+        "format": "json",
+        "content": {
+            "test_keys": {},
+            "annotations": {"platform": "test_platform"},
+            "software_name": "test_software",
+            "software_version": "0.0.0",
+        },
+    }
+    resp = client.post(f"/report/{rid}", json=msmt_payload)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "measurement_uid" in body, body
+    msmt_uid = body["measurement_uid"]
+    assert msmt_uid, body
+
+    expected_hash = _get_hash_of(msmt_payload)
+    assert msmt_uid.endswith(f"_IT_integtest_{expected_hash}"), msmt_uid
+
+    # check saved data
+    expected_url = f"{success_url}/{msmt_uid}"
+    assert list(mock_fastpath.uploads.keys()) == [expected_url]
+
+    stored = mock_fastpath.uploads[expected_url]
+    assert sha512(stored).hexdigest()[:16] == expected_hash
+    assert ujson.loads(stored)["is_verified"] == "u"
 
 def _get_hash_of(msmt: dict) -> str:
     payload = copy.deepcopy(msmt)

--- a/ooniapi/services/ooniprobe/tests/test_anoncred.py
+++ b/ooniapi/services/ooniprobe/tests/test_anoncred.py
@@ -1,3 +1,4 @@
+from hashlib import sha512
 from typing import Any, Dict
 import ooniauth_py
 import pytest
@@ -7,7 +8,7 @@ from ooniauth_py import UserState, ServerState
 from pydantic import ValidationError
 from ooniprobe.dependencies import Manifest, Match, Policy, PolicyEntry
 from ooniprobe.routers.v1.probe_services import get_ranges_from_policy
-from .utils import getj, make_submit_request, postj, setup_user
+from .utils import get_msmt_hash, getj, make_submit_request, postj, setup_user
 
 @pytest.mark.asyncio
 async def test_manifest_basic(client, db):
@@ -97,6 +98,47 @@ async def test_submission_basic(client):
     assert c['submit_response'], "Submit response should not be null if the proof was verified"
     user.handle_submit_response(c['submit_response'])
     assert c["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_fastpath_fallback(client_with_mocked_fastpath):
+    """
+    When the first fastpath URL fails, the second one in the list should
+    still receive a verified anonymous-credentials measurement.
+    """
+    client, mock_fastpath, success_url = client_with_mocked_fastpath
+
+    # open report
+    j = make_report_request("IE", "AS34245")
+    resp = postj(client, "/report", json=j)
+    rid = resp.pop("report_id")
+
+    # build a verifiable submission
+    user, manifest_version, _ = setup_user(client)
+    submit_request = make_submit_request(user, "IE", "AS34245")
+    msm = make_measurement(submit_request.nym, submit_request.request, manifest_version)
+
+    c = postj(client, f"/api/v1/submit_measurement/{rid}", msm)
+    assert c["verification_status"] == "verified", c
+    assert c["error"] is None, c
+    assert c["submit_response"], (
+        "submit_response should not be null when verification succeeded"
+    )
+    msmt_uid = c["measurement_uid"]
+    assert msmt_uid, c
+
+    # Verified anonymous-credential submissions inject "t" as the
+    # `is_verified` flag in the stored payload before hashing.
+    expected_hash = get_msmt_hash(msm, is_verified="t")
+    assert msmt_uid.endswith(f"_IE_webconnectivity_{expected_hash}"), msmt_uid
+
+    # Check response bytes
+    expected_url = f"{success_url}/{msmt_uid}"
+    assert list(mock_fastpath.uploads.keys()) == [expected_url]
+
+    stored = mock_fastpath.uploads[expected_url]
+    assert sha512(stored).hexdigest()[:16] == expected_hash
+    assert ujson.loads(stored)["is_verified"] == "t"
 
 
 @pytest.mark.asyncio

--- a/ooniapi/services/ooniprobe/tests/test_anoncred.py
+++ b/ooniapi/services/ooniprobe/tests/test_anoncred.py
@@ -141,6 +141,41 @@ async def test_fastpath_fallback(client_with_mocked_fastpath):
 
 
 @pytest.mark.asyncio
+async def test_fastpath_only_submits_once_on_success(client_with_two_working_fastpaths):
+    """
+    When the first fastpath URL succeeds, the receiver should stop iterating
+    """
+    client, mock_fastpath, first_url, second_url = client_with_two_working_fastpaths
+
+    # open report
+    j = make_report_request("IE", "AS34245")
+    resp = postj(client, "/report", json=j)
+    rid = resp.pop("report_id")
+
+    # build a verifiable submission
+    user, manifest_version, _ = setup_user(client)
+    submit_request = make_submit_request(user, "IE", "AS34245")
+    msm = make_measurement(submit_request.nym, submit_request.request, manifest_version)
+
+    c = postj(client, f"/api/v1/submit_measurement/{rid}", msm)
+    assert c["verification_status"] == "verified", c
+    assert c["error"] is None, c
+    msmt_uid = c["measurement_uid"]
+    assert msmt_uid, c
+
+    # Sanity-check the bytes that were forwarded to the fastpath
+    expected_hash = get_msmt_hash(msm, is_verified="t")
+    assert msmt_uid.endswith(f"_IE_webconnectivity_{expected_hash}"), msmt_uid
+
+    # Only the first fastpath URL should have received the measurement
+    expected_url = f"{first_url}/{msmt_uid}"
+    assert list(mock_fastpath.uploads.keys()) == [expected_url], (
+        "measurement should be forwarded to the first fastpath URL only, "
+        f"got {list(mock_fastpath.uploads.keys())}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_submission_non_verified(client):
     """
 

--- a/ooniapi/services/ooniprobe/tests/test_anoncred.py
+++ b/ooniapi/services/ooniprobe/tests/test_anoncred.py
@@ -1,4 +1,3 @@
-from hashlib import sha512
 from typing import Any, Dict
 import ooniauth_py
 import pytest
@@ -136,9 +135,9 @@ async def test_fastpath_fallback(client_with_mocked_fastpath):
     expected_url = f"{success_url}/{msmt_uid}"
     assert list(mock_fastpath.uploads.keys()) == [expected_url]
 
-    stored = mock_fastpath.uploads[expected_url]
-    assert sha512(stored).hexdigest()[:16] == expected_hash
-    assert ujson.loads(stored)["is_verified"] == "t"
+    stored = ujson.loads(mock_fastpath.uploads[expected_url])
+    assert get_msmt_hash(stored, is_verified="t") == expected_hash
+    assert stored["is_verified"] == "t"
 
 
 @pytest.mark.asyncio

--- a/ooniapi/services/ooniprobe/tests/utils.py
+++ b/ooniapi/services/ooniprobe/tests/utils.py
@@ -1,7 +1,10 @@
+import copy
+from hashlib import sha512
 from httpx import Client
 from typing import Dict, Any
 from fastapi import status
 from typing import Tuple
+import ujson
 from ooniauth_py import UserState
 
 def getj(client : Client, url: str, params: Dict[str, Any] = {}) -> Dict[str, Any]:
@@ -44,3 +47,9 @@ def make_submit_request(user: UserState, probe_cc: str, probe_asn: str):
         (2461110, 2826140),
         (0, 10000000),
     )
+
+
+def get_msmt_hash(msmt: Dict[str, Any], is_verified: str = "u") -> str:
+    payload = copy.deepcopy(msmt)
+    payload["is_verified"] = is_verified
+    return sha512(ujson.dumps(payload).encode()).hexdigest()[:16]

--- a/ooniapi/services/testlists/src/testlists/main.py
+++ b/ooniapi/services/testlists/src/testlists/main.py
@@ -112,14 +112,15 @@ async def health(
         errors.append("clickhouse_error")
         log.error(e)
 
-    try:
-        response = urlopen(settings.fastpath_url)
-        assert (
-            response.status == 200
-        ), "Unexpected status trying to connect to fastpath: " + str(response.status)
-    except Exception as exc:
-        log.error(str(exc))
-        errors.append("fastpath_connection_error")
+    for fastpath_url in settings.fastpath_urls:
+        try:
+            response = urlopen(fastpath_url)
+            assert (
+                response.status == 200
+            ), "Unexpected status trying to connect to fastpath: " + str(response.status)
+        except Exception as exc:
+            log.error(str(exc))
+            errors.append("fastpath_connection_error")
 
     if settings.jwt_encryption_key == "CHANGEME":
         errors.append("bad_jwt_secret")

--- a/ooniapi/services/testlists/tests/conftest.py
+++ b/ooniapi/services/testlists/tests/conftest.py
@@ -225,7 +225,7 @@ def test_settings(alembic_migration, clickhouse_server, fastpath_server, tmp_pat
         prometheus_metrics_password="super_secure",
         clickhouse_url=clickhouse_server,
         collector_id="1",
-        fastpath_url=fastpath_server,
+        fastpath_urls=[fastpath_server],
         working_dir=str(tmp_path),
         github_user="fakeuser",
         github_token="faketoken",


### PR DESCRIPTION
This PR will add the ability to specify a list of fastpath fallback URLs to ooniprobe. If sending a measurement fails in a fastpath instance, it will retry with the next one until all fallbacks fail or the measurement is finally sent. 

This PR will also deprecate the current `fastpath_url` setting to replace it with `fastpath_urls`. In the meanwhile, the handler endpoint will join the `fastpath_url` parameter with the `fastpath_urls` parameter to construct the list of fallbacks, but we have to remove the `fastpath_url` parameter in the future. 

Also note that oonimeasurements already supports looking up measurements from several spool dirs using the `OTHER_COLLECTORS`, we should keep them on sync in terraform  

# How to migrate

1. Merge and deploy this code
2. Deploy secondary fastpath instance 
3. Update terraform to add current fastpath instance and new one to the list of fallbacks

After this migration is applied we can safely remove the `fastpath_url` parameter 

closes #1190 