### PR TITLE
fix testlists /health check; do not query fastpath

### DIFF
--- a/ooniapi/services/testlists/src/testlists/main.py
+++ b/ooniapi/services/testlists/src/testlists/main.py
@@ -97,29 +97,18 @@ class HealthStatus(BaseModel):
 @app.get("/health")
 async def health(
     settings: SettingsDep,
-    db: PostgresDep,
     clickhouse: ClickhouseDep,
 ):
     errors = []
     try:
         query = """
         SELECT COUNT()
-        FROM fastpath
-        WHERE measurement_start_time < NOW() AND measurement_start_time > NOW() - INTERVAL 3 HOUR
+        FROM citizenlab
         """
         query_click(db=clickhouse, query=query, query_params={})
     except Exception as e:
         errors.append("clickhouse_error")
         log.error(e)
-
-    try:
-        response = urlopen(settings.fastpath_url)
-        assert (
-            response.status == 200
-        ), "Unexpected status trying to connect to fastpath: " + str(response.status)
-    except Exception as exc:
-        log.error(str(exc))
-        errors.append("fastpath_connection_error")
 
     if settings.jwt_encryption_key == "CHANGEME":
         errors.append("bad_jwt_secret")


### PR DESCRIPTION
query citizenlab table instead of fastpath and do not query fastpath service as part of health check