### PR TITLE
remove unused clickhouse-driver

### DIFF
--- a/ooniapi/services/oonifindings/pyproject.toml
+++ b/ooniapi/services/oonifindings/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
   "fastapi ~= 0.108.0",
   "boto3 ~= 1.39.3",
   "mypy-boto3-s3 ~= 1.39.5",
-  "clickhouse-driver ~= 0.2.6",
   "sqlalchemy ~= 2.0.27",
   "pydantic-settings ~= 2.1.0", 
   "uvicorn ~= 0.25.0",


### PR DESCRIPTION
remove unused dependency clickhouse-driver from pyproject.toml