### PR TITLE
Make only one fastpath required for healthcheck

### DIFF
--- a/ooniapi/services/ooniprobe/src/ooniprobe/main.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/main.py
@@ -126,14 +126,18 @@ async def health(
         errors.append("clickhouse_error")
         log.error(e)
 
+    fp_ok = False
     for fastpath_url in settings.fastpath_urls:
         try:
-            resp = await run_in_threadpool(app.state.fastpath_client.get, fastpath_url)
+            resp = await run_in_threadpool(app.state.fastpath_client.get, fastpath_url, timeout=5)
             with resp:
                 resp.raise_for_status()
+            fp_ok = True
         except Exception as exc:
             log.error(f"Unable to connect with fastpath '{fastpath_url}'. Error: {exc}")
-            errors.append("fastpath_connection_error")
+
+    if not fp_ok:
+        errors.append("fastpath_connection_error")
 
 
     try:


### PR DESCRIPTION
This PR will change the health check in ooniprobe to require only one fastpath to be responsive instead of every fastpath at the same time 