### PR TITLE
add setting fastpath_timeout; requests does not timeout by default

### DIFF
--- a/ooniapi/common/src/common/config.py
+++ b/ooniapi/common/src/common/config.py
@@ -50,6 +50,7 @@ class Settings(BaseSettings):
         description="List of fastpath instances to send measurements to",
         default_factory=list,
     ) # example: [http://123.123.123.123:8472]
+    fastpath_timeout: int = 5
 
     failed_reports_bucket: str = (
         ""  # for uploading reports that couldn't be sent to fastpath

--- a/ooniapi/common/src/common/config.py
+++ b/ooniapi/common/src/common/config.py
@@ -50,7 +50,7 @@ class Settings(BaseSettings):
         description="List of fastpath instances to send measurements to",
         default_factory=list,
     ) # example: [http://123.123.123.123:8472]
-    fastpath_timeout: int = 5
+    fastpath_timeout: int = 10
 
     failed_reports_bucket: str = (
         ""  # for uploading reports that couldn't be sent to fastpath

--- a/ooniapi/services/ooniprobe/src/ooniprobe/main.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/main.py
@@ -127,9 +127,10 @@ async def health(
         log.error(e)
 
     fp_ok = False
+    timeout = settings.fastpath_timeout
     for fastpath_url in settings.fastpath_urls:
         try:
-            resp = await run_in_threadpool(app.state.fastpath_client.get, fastpath_url, timeout=5)
+            resp = await run_in_threadpool(app.state.fastpath_client.get, fastpath_url, timeout=timeout)
             with resp:
                 resp.raise_for_status()
             fp_ok = True

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
@@ -177,13 +177,14 @@ async def receive_measurement(
 
     client = request.app.state.fastpath_client
     fastpath_urls = settings.fastpath_urls
+    timeout = settings.fastpath_timeout
     success = False
     for (i, fastpath_url) in enumerate(fastpath_urls):
         with Metrics.SEND_FASTPATH_TIMING.time():
             try:
                 url = f"{fastpath_url}/{msmt_uid}"
 
-                resp = await run_in_threadpool(client.post, url, data=data)
+                resp = await run_in_threadpool(client.post, url, data=data, timeout=timeout)
                 with resp:
                     resp.raise_for_status()
                 Metrics.SEND_FASTPATH_CNT.labels(


### PR DESCRIPTION
adds a configurable timeout value for posting to fastpath; by default requests does not timeout