### PR TITLE
Update anonymous credentials to bind submission to measurement

### DIFF
--- a/ooniapi/services/ooniprobe/pyproject.toml
+++ b/ooniapi/services/ooniprobe/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "boto3 ~= 1.39.3",
   "boto3-stubs[s3] ~= 1.39.3",
   "mypy-boto3-s3 ~= 1.39.5",
-  "ooniauth-py==0.3.0"
+  "ooniauth-py==0.3.1"
 ]
 
 readme = "README.md"

--- a/ooniapi/services/ooniprobe/pyproject.toml
+++ b/ooniapi/services/ooniprobe/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "boto3 ~= 1.39.3",
   "boto3-stubs[s3] ~= 1.39.3",
   "mypy-boto3-s3 ~= 1.39.5",
-  "ooniauth-py==0.2.1"
+  "ooniauth-py==0.3.0"
 ]
 
 readme = "README.md"

--- a/ooniapi/services/ooniprobe/src/ooniprobe/download_geoip.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/download_geoip.py
@@ -63,7 +63,7 @@ def is_latest_available(url: str) -> bool:
         resp = get_request(url)
         return resp.status == 200
     except HTTPError as err:
-        if resp.status == 404:  # type: ignore
+        if err.code == 404:
             log.info(f"{url} hasn't been updated yet")
             return False
         log.info(f"unexpected status code '{err.code}' in {url}")

--- a/ooniapi/services/ooniprobe/src/ooniprobe/download_geoip.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/download_geoip.py
@@ -63,7 +63,7 @@ def is_latest_available(url: str) -> bool:
         resp = get_request(url)
         return resp.status == 200
     except HTTPError as err:
-        if resp.status == 404:  # type: ignore
+        if err.status == 404:  # type: ignore
             log.info(f"{url} hasn't been updated yet")
             return False
         log.info(f"unexpected status code '{err.code}' in {url}")

--- a/ooniapi/services/ooniprobe/src/ooniprobe/download_geoip.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/download_geoip.py
@@ -12,6 +12,7 @@ import logging
 import maxminddb
 from pathlib import Path
 from datetime import datetime, timezone
+from dateutil.relativedelta import relativedelta
 from urllib.error import HTTPError
 from urllib.request import urlopen, Request
 
@@ -63,11 +64,32 @@ def is_latest_available(url: str) -> bool:
         resp = get_request(url)
         return resp.status == 200
     except HTTPError as err:
-        if err.status == 404:  # type: ignore
+        if err.code == 404:
             log.info(f"{url} hasn't been updated yet")
             return False
         log.info(f"unexpected status code '{err.code}' in {url}")
         return False
+
+
+def geoip_release_url(release_date: datetime) -> tuple[str, str, str]:
+    ts = release_date.strftime("%Y-%m-01")
+    ver = release_date.strftime("%Y%m01")
+    url = (
+        "https://github.com/ooni/historical-geoip/releases/download/"
+        f"{ver}/{ver}-ip2country_as.mmdb.gz"
+    )
+    return ts, ver, url
+
+
+def has_valid_geoip_db(db_dir: Path) -> bool:
+    db_path = db_dir / "asn_cc.mmdb"
+    if not db_path.exists():
+        return False
+    try:
+        check_geoip_db(db_path)
+    except Exception:
+        return False
+    return True
 
 
 def check_geoip_db(path: Path) -> None:
@@ -119,24 +141,35 @@ def update_geoip(db_dir: Path, ts: str, asn_cc_url) -> None:
     with (db_dir / "geoipdbts").open("w") as out_file:
         out_file.write(ts)
 
-    log.info("Updated GeoIP databases")
+    log.info("Updated GeoIP databases to time: " + ts)
     Metrics.GEOIP_UPDATED.inc()
 
 
-def try_update(db_dir: str):
+def try_update(db_dir: str, max_months_back: int = 1):
     db_dir_path = Path(db_dir)
+    now = datetime.now(timezone.utc)
+    current_ts, _, current_url = geoip_release_url(now)
 
-    ts = datetime.now(timezone.utc).strftime("%Y-%m-01")
-    ver = datetime.now(timezone.utc).strftime("%Y%m01")
-
-    asn_cc_url = f"https://github.com/ooni/historical-geoip/releases/download/{ver}/{ver}-ip2country_as.mmdb.gz"
-
-    if is_already_updated(db_dir_path, ts):
+    if is_already_updated(db_dir_path, current_ts):
         log.debug("Database already updated. Exiting.")
         return
 
-    if not is_latest_available(asn_cc_url):
-        log.debug("Update not available yet. Exiting.")
+    if is_latest_available(current_url):
+        update_geoip(db_dir_path, current_ts, current_url)
         return
 
-    update_geoip(db_dir_path, ts, asn_cc_url)
+    if has_valid_geoip_db(db_dir_path):
+        log.debug(
+            "Current month GeoIP database not available yet; keeping existing database."
+        )
+        return
+
+    for months_back in range(1, max_months_back + 1):
+        release_date = now - relativedelta(months=months_back)
+        ts, _, url = geoip_release_url(release_date)
+        if not is_latest_available(url):
+            continue
+        update_geoip(db_dir_path, ts, url)
+        return
+
+    log.debug("No GeoIP update available. Exiting.")

--- a/ooniapi/services/ooniprobe/src/ooniprobe/download_geoip.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/download_geoip.py
@@ -164,6 +164,11 @@ def try_update(db_dir: str, max_months_back: int = 1):
         )
         return
 
+    log.warning(
+        "No existent geoip found and no new version available: "
+        "falling back to older versions"
+    )
+
     for months_back in range(1, max_months_back + 1):
         release_date = now - relativedelta(months=months_back)
         ts, _, url = geoip_release_url(release_date)

--- a/ooniapi/services/ooniprobe/src/ooniprobe/main.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/main.py
@@ -209,7 +209,7 @@ def check_ooniauth_health():
     # These keys are innocuous, just created to test this
     secret_key = "AUGQSPO28+QLlf8fKhQjqAD2Ehjn0Q471Yavs7n0qsYJ0nnZ1G/Y2LqvjC3Stq0o9Ka6lB2Xq9EDIEOFhQsjbQQDAAAAAAAAAGk422WHZ5MEPCTMbaj4sDvW27Yvl+pRzDuuTasyEpIDRCEzgL3tIOErnbYtca/68gHUxIfXRCDtcSMEvxVhSAynRFLeT0pXf5fRFwX4gbzNVgvzh0MthADyh7UUPmj6BQ=="
     public_parameters = "AaJpxHsB+x4axWCrFxohF+ML5inYWbPbVQro9YGxb9NVAcgzlHrnd7PLfwWQe69W3ZLcGe4R/CnbFBwhCfdfvvpCAwAAAAAAAAAkAklNBr7fMUrdkeNT360ZsLTGN8A7kKMX6b60tJ5YCBLJ9QJdwnkp12VHPgND2/chraDFw8snqfq0JDZI2tJ04sqKzWi+y57qzh0HG+pkZ3xe7RceyE4isTs7ZRzriwA="
-    sign_request = "6iOCB9U1J7UowHfVGq0zoWiP2zSi7589rqS7bdNBC2NlAAAAAAAAAAPW0h/qB7voDedoLiDttZwawVv7xdlZY7GkbijU+o+RAAIAAAAKx1aegNytJO5oarCsIx0t5FQpqP5Wm54k+ECb9nVh7wqQpREN1uu20ZqgU4iW8XDwzOnw8IfWJBSv7FTaF0ne"
+    sign_request = "cmMXB7zv9Dw2/BG7Jg6UF4/F1c8/I6L1I/Ho7wgf1l9lAAAAAAAAAAHvLcAyEvy8L82lVWoL1kQq8Okc8vo40oq8DctqvAYcAAIAAAAGaegxFhhwDPfWPET8p2g8nSY2QEVBn21+uLED8ZNFzgbszewhiFlvRAA0unHZ2Ntje0I3rvjJHNmv5eJC2H56"
 
     server = ServerState.from_creds(public_parameters, secret_key)
     server.handle_registration_request(sign_request)

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -1138,13 +1138,25 @@ def _verify_submit(
 def _clear_sensible_data(data : dict[str, Any]):
     """
     `data` encodes a SubmitMeasurementRequest as dict, this function
-    will create a new dict without fields with sensible information
+    will create a new dict without fields with sensible information.
+
+    The fields that should not be present in the measurement body are:
+        - zkp_request
+        - nym
+
+    These should only be used during verification, don't store them long term
     """
 
     d = {
         "content": data.get("content"),
         "format": data.get("format"),
     }
+
+    if 'protocol_version' in data:
+        d['protocol_version'] = data['protocol_version']
+
+    if 'manifest_version' in data:
+        d['manifest_version'] = data['manifest_version']
 
     return d
 

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -937,8 +937,8 @@ async def submit_measurement(
     data = submit_request.model_dump()
     data["content"] = content # change from string to dict
 
-    # Clear sensible data before sending it to fastpath
-    data = _clear_sensible_data(data)
+    # Clear sensitive data before sending it to fastpath
+    data = _clear_sensitive_data(data)
 
     # Add verification-related data.
     # use one-letter code for DB, human readable for clients
@@ -1135,16 +1135,17 @@ def _verify_submit(
         log.error(f"Unexpected anonc error: {e}")
         return (VerificationStatus.FAILED, "unknown_error", None)
 
-def _clear_sensible_data(data : dict[str, Any]):
+def _clear_sensitive_data(data : dict[str, Any]):
     """
     `data` encodes a SubmitMeasurementRequest as dict, this function
-    will create a new dict without fields with sensible information.
+    will create a new dict without fields with sensitive information.
 
     The fields that should not be present in the measurement body are:
         - zkp_request
         - nym
 
-    These should only be used during verification, don't store them long term
+    These should only be used during verification, they can leak identifying
+    data, don't store them long term.
     """
 
     d = {

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -825,7 +825,7 @@ def to_http_exception(error: ProtocolError | CredentialError | DeserializationFa
 
 class SubmitMeasurementRequest(BaseModel):
     format: str
-    content: Dict[str, Any]
+    content: str
     # -- < Anonymous Credentials > ----------------------
     # not post quantum, in the future we might want to use a hashed key for storage
     nym: str | None = None
@@ -901,7 +901,23 @@ async def submit_measurement(
     """
     setnocacheresponse(response)
 
-    metadata = metadata_from_measurement_content(submit_request.content)
+    # Parse content string
+    try:
+        content : dict[str, Any] = await run_in_threadpool(
+            ujson.loads,
+            submit_request.content
+        )
+        assert isinstance(content, dict), "'content' should be a json encoded as a string"
+    except Exception as e:
+        log.error(f"invalid content: {e}")
+        raise HTTPException(
+            status_code = status.HTTP_400_BAD_REQUEST,
+            detail = {
+                "error" : str(e)
+            }
+        )
+
+    metadata = metadata_from_measurement_content(content)
 
     test_name = metadata.test_name
     cc = metadata.probe_cc
@@ -912,14 +928,17 @@ async def submit_measurement(
     # generate the new report_id
     rid = generate_report_id(test_name, settings, cc, normalize_asn(asn))
 
-    json_bytes = await request.body()
-
     # Anonymous credentials verification
     verification_status, submit_error, submit_response = _verify_submit(
-        json_bytes, submit_request, manifest, settings
+        submit_request, manifest, settings,
+        content.get('probe_cc'), content.get('probe_asn')
     )
 
     data = submit_request.model_dump()
+    data["content"] = content # change from string to dict
+
+    # Clear sensible data before sending it to fastpath
+    data = _clear_sensible_data(data)
 
     # Add verification-related data.
     # use one-letter code for DB, human readable for clients
@@ -1027,10 +1046,11 @@ async def submit_measurement(
     )
 
 def _verify_submit(
-    json_bytes: bytes,
     submit_request: SubmitMeasurementRequest,
     manifest: ManifestDep,
     settings: SettingsDep,
+    probe_cc: str | None,
+    probe_asn: str | None
 ) -> tuple[VerificationStatus, str | None, str | None]:
     """
     Run the anonymous credentials verification when the relevant fields are present.
@@ -1063,8 +1083,8 @@ def _verify_submit(
         or submit_request.zkp_request is None
         or submit_request.manifest_version is None
         or submit_request.protocol_version is None
-        or "probe_cc" not in submit_request.content
-        or "probe_asn" not in submit_request.content
+        or probe_cc is None
+        or probe_asn is None
     ):
         log.error("Incomplete anonymous credentials fields in submission request")
         return VerificationStatus.UNVERIFIED, "incomplete_anonc_fields", None
@@ -1089,11 +1109,17 @@ def _verify_submit(
     # Get the age range and minimum measurement count for this request
     age_range, min_msm_count = get_ranges_from_policy(
         manifest.manifest.submission_policy,
-        submit_request.content["probe_cc"],
-        submit_request.content["probe_asn"],
+        probe_cc,
+        probe_asn,
     )
 
-    measurement_hash = b64encode(sha256(json_bytes).digest()).decode()
+    measurement_hash = b64encode(
+        sha256(
+            submit_request.content.encode()
+        )
+        .digest()
+    ).decode()
+
     # Run verification
     try:
         protocol_state = ServerState.from_creds(
@@ -1102,8 +1128,8 @@ def _verify_submit(
         submit_response = protocol_state.handle_submit_request(
             submit_request.nym,
             submit_request.zkp_request,
-            submit_request.content["probe_cc"],
-            submit_request.content["probe_asn"],
+            probe_cc,
+            probe_asn,
             measurement_hash,
             age_range,
             min_msm_count,
@@ -1115,6 +1141,19 @@ def _verify_submit(
     except Exception as e:
         log.error(f"Unexpected anonc error: {e}")
         return (VerificationStatus.FAILED, "unknown_error", None)
+
+def _clear_sensible_data(data : dict[str, Any]):
+    """
+    `data` encodes a SubmitMeasurementRequest as dict, this function
+    will create a new dict without fields with sensible information
+    """
+
+    d = {
+        "content": data.get("content"),
+        "format": data.get("format"),
+    }
+
+    return d
 
 
 def _parse_version_tuple(version: str) -> tuple[int, ...]:

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -5,7 +5,8 @@ import random
 import time
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from hashlib import sha512
+from base64 import b64encode
+from hashlib import sha512, sha256
 from typing import (
     List,
     Any,
@@ -911,9 +912,11 @@ async def submit_measurement(
     # generate the new report_id
     rid = generate_report_id(test_name, settings, cc, normalize_asn(asn))
 
+    json_bytes = await request.body()
+
     # Anonymous credentials verification
     verification_status, submit_error, submit_response = _verify_submit(
-        submit_request, manifest, settings
+        json_bytes, submit_request, manifest, settings
     )
 
     data = submit_request.model_dump()
@@ -1024,6 +1027,7 @@ async def submit_measurement(
     )
 
 def _verify_submit(
+    json_bytes: bytes,
     submit_request: SubmitMeasurementRequest,
     manifest: ManifestDep,
     settings: SettingsDep,
@@ -1089,6 +1093,7 @@ def _verify_submit(
         submit_request.content["probe_asn"],
     )
 
+    measurement_hash = b64encode(sha256(json_bytes).digest()).decode()
     # Run verification
     try:
         protocol_state = ServerState.from_creds(
@@ -1099,6 +1104,7 @@ def _verify_submit(
             submit_request.zkp_request,
             submit_request.content["probe_cc"],
             submit_request.content["probe_asn"],
+            measurement_hash,
             age_range,
             min_msm_count,
         )

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -1113,24 +1113,17 @@ def _verify_submit(
         probe_asn,
     )
 
-    measurement_hash = b64encode(
-        sha256(
-            submit_request.content.encode()
-        )
-        .digest()
-    ).decode()
-
     # Run verification
     try:
         protocol_state = ServerState.from_creds(
             manifest.manifest.public_parameters, settings.anonc_secret_key
         )
-        submit_response = protocol_state.handle_submit_request(
+        submit_response = protocol_state.handle_submit_request_with_hash(
             submit_request.nym,
             submit_request.zkp_request,
             probe_cc,
             probe_asn,
-            measurement_hash,
+            submit_request.content,
             age_range,
             min_msm_count,
         )

--- a/ooniapi/services/ooniprobe/tests/integ/test_geolookup.py
+++ b/ooniapi/services/ooniprobe/tests/integ/test_geolookup.py
@@ -8,8 +8,8 @@ from ooniprobe import utils
 from ooniprobe.dependencies import ASNCCReaderDep
 from ooniprobe.common.clickhouse_utils import query_click_one_row
 from clickhouse_driver import Client as Clickhouse
-from ..utils import make_submit_request, postj, setup_user
-from ..test_anoncred import make_measurement, make_report_request
+from ..utils import postj, setup_user
+from ..test_anoncred import make_measurement_body, make_report_request, make_verified_measurement
 
 
 def fake_geolookup_probe(ipaddr: str, asn_cc_reader: ASNCCReaderDep) -> Tuple:
@@ -156,21 +156,18 @@ async def test_geoip_mismatch_anoncred(client, clickhouse_db, clean_faulty_measu
 
     # Create anoncred user and submit_request
     user, manifest_version, emission_day = setup_user(client)
-    submit_request = make_submit_request(user, "VE", "AS65550")
+    body = make_measurement_body(probe_asn="AS65550", probe_cc="VE")
+    body["software_name"] = "ooni-integ-test"
+    body["software_version"] = "0.0.0"
+    body["annotations"] = {"platform": "linux"}
 
-    # Build measurement body for `/api/v1/submit_measurement`
-    msm = make_measurement(
-        submit_request.nym,
-        submit_request.request,
+    msm = make_verified_measurement(
+        user,
         manifest_version,
         probe_cc="VE",
         probe_asn="AS65550",
+        body=body,
     )
-    msm_content = msm.setdefault("content", {})
-    msm_content["software_name"] = "ooni-integ-test"
-    msm_content["software_version"] = "0.0.0"
-    msm_content["annotations"] = {"platform": "linux"}
-
 
     # matching cc and asn
     postj(

--- a/ooniapi/services/ooniprobe/tests/test_anoncred.py
+++ b/ooniapi/services/ooniprobe/tests/test_anoncred.py
@@ -83,9 +83,7 @@ async def test_submission_basic(client):
     # Create user
     user, manifest_version, emission_day = setup_user(client)
 
-    submit_request = make_submit_request(user, "IE", "AS34245")
-
-    msm = make_measurement(submit_request.nym, submit_request.request, manifest_version)
+    msm = make_verified_measurement(user, manifest_version)
 
     c = postj(client, "/api/v1/submit_measurement", msm)
     assert c["verification_status"] == "verified", c
@@ -105,8 +103,7 @@ async def test_fastpath_fallback(client_with_one_good_mocked_fastpath):
 
     # build a verifiable submission
     user, manifest_version, _ = setup_user(client)
-    submit_request = make_submit_request(user, "IE", "AS34245")
-    msm = make_measurement(submit_request.nym, submit_request.request, manifest_version)
+    msm = make_verified_measurement(user, manifest_version)
 
     c = postj(client, "/api/v1/submit_measurement", msm)
     assert c["verification_status"] == "verified", c
@@ -140,10 +137,7 @@ async def test_fastpath_payload_has_report_id(client_with_mocked_fastpath):
 
     # 1) Verified anonymous-credentials submission
     user, manifest_version, _ = setup_user(client)
-    submit_request = make_submit_request(user, "IE", "AS34245")
-    msm_verified = make_measurement(
-        submit_request.nym, submit_request.request, manifest_version
-    )
+    msm_verified = make_verified_measurement(user, manifest_version)
     c = postj(client, "/api/v1/submit_measurement", msm_verified)
     assert c["verification_status"] == "verified", c
     verified_uid = c["measurement_uid"]
@@ -151,12 +145,14 @@ async def test_fastpath_payload_has_report_id(client_with_mocked_fastpath):
     # 2) Unverified submission (missing anoncred fields)
     msm_unverified = {
         "format": "json",
-        "content": {
-            "test_name": "web_connectivity",
-            "probe_asn": "AS34245",
-            "probe_cc": "IE",
-            "test_start_time": "2020-09-09 14:11:11",
-        },
+        "content": ujson.dumps(
+            {
+                "test_name": "web_connectivity",
+                "probe_asn": "AS34245",
+                "probe_cc": "IE",
+                "test_start_time": "2020-09-09 14:11:11",
+            }
+        ),
     }
     c = postj(client, "/api/v1/submit_measurement", msm_unverified)
     assert c["verification_status"] == "unverified", c
@@ -184,8 +180,7 @@ async def test_fastpath_only_submits_once_on_success(client_with_two_working_fas
 
     # build a verifiable submission
     user, manifest_version, _ = setup_user(client)
-    submit_request = make_submit_request(user, "IE", "AS34245")
-    msm = make_measurement(submit_request.nym, submit_request.request, manifest_version)
+    msm = make_verified_measurement(user, manifest_version)
 
     c = postj(client, "/api/v1/submit_measurement", msm)
     assert c["verification_status"] == "verified", c
@@ -211,14 +206,10 @@ async def test_submission_non_verified(client):
     """
 
     """
+    body = make_measurement_body(probe_asn="AS34245", probe_cc="IE")
     msm = {
         "format": "json",
-        "content": {
-            "test_name": "web_connectivity",
-            "probe_asn": "AS34245",
-            "probe_cc": "IE",
-            "test_start_time": "2020-09-09 14:11:11",
-        },
+        "content": ujson.dumps(body),
     }
 
     # no anoncred fields -> processed but not verified, no error
@@ -244,7 +235,7 @@ async def test_submission_non_verified(client):
     assert c["error"] == "incomplete_anonc_fields"
 
     # old protocol version -> protocol-version error
-    submit_request = make_submit_request(user, "IE", "AS34245")
+    submit_request = make_submit_request(user, "IE", "AS34245", ujson.dumps(body))
     msm["nym"] = submit_request.nym
     msm["zkp_request"] = submit_request.request
     msm["manifest_version"] = manifest_version
@@ -522,9 +513,7 @@ async def test_credential_update_with_submission(client, client_with_original_ma
     (user, manifest_version, emission_day) = client_with_original_manifest
 
     # first submit: should just work out of the box
-    submit_request = make_submit_request(user, "IE", "AS34245")
-
-    msm = make_measurement(submit_request.nym, submit_request.request, manifest_version)
+    msm = make_verified_measurement(user, manifest_version)
 
     c = postj(client, "/api/v1/submit_measurement", msm)
 
@@ -542,11 +531,37 @@ async def test_credential_update_with_submission(client, client_with_original_ma
     assert 'update_response' in result
     user.handle_credential_update_response(result['update_response']) # should not crash
 
-    submit_request = make_submit_request(user, "IE", "AS34245")
-
-    msm = make_measurement(submit_request.nym, submit_request.request, manifest_version)
+    body = make_measurement_body(probe_asn="AS34245", probe_cc="IE")
+    msm = make_verified_measurement(user, manifest_version, body=body)
 
     c = postj(client, "/api/v1/submit_measurement", msm)
+
+def make_measurement_body(probe_asn: str, probe_cc: str) -> dict:
+    return {
+        "test_name": "web_connectivity",
+        "probe_asn": probe_asn,
+        "probe_cc": probe_cc,
+        "test_start_time": "2020-09-09 14:11:11",
+    }
+
+
+def make_verified_measurement(
+    user: UserState,
+    manifest_version: str,
+    probe_cc: str = "IE",
+    probe_asn: str = "AS34245",
+    body: Dict[str, Any] | None = None,
+) -> Dict[str, Any]:
+    body = body or make_measurement_body(probe_asn, probe_cc)
+    submit_request = make_submit_request(user, probe_cc, probe_asn, ujson.dumps(body))
+    return make_measurement(
+        submit_request.nym,
+        submit_request.request,
+        manifest_version,
+        probe_cc=probe_cc,
+        probe_asn=probe_asn,
+        content=body,
+    )
 
 
 def make_measurement(
@@ -556,15 +571,11 @@ def make_measurement(
     probe_cc: str = "IE",
     probe_asn: str = "AS34245",
     protocol_version: str = ooniauth_py.get_protocol_version(),
+    content : dict | None = None
 ) -> Dict[str, Any]:
     return {
         "format": "json",
-        "content": {
-            "test_name": "web_connectivity",
-            "probe_asn": probe_asn,
-            "probe_cc": probe_cc,
-            "test_start_time": "2020-09-09 14:11:11",
-        },
+        "content": ujson.dumps(content or make_measurement_body(probe_asn, probe_cc)),
         "nym": nym,
         "zkp_request": zkp_request,
         "manifest_version": manifest_version,

--- a/ooniapi/services/ooniprobe/tests/test_anoncred.py
+++ b/ooniapi/services/ooniprobe/tests/test_anoncred.py
@@ -8,7 +8,7 @@ from ooniauth_py import UserState, ServerState
 from pydantic import ValidationError
 from ooniprobe.dependencies import Manifest, Match, Policy, PolicyEntry
 from ooniprobe.routers.v1.probe_services import (
-    _clear_sensible_data,
+    _clear_sensitive_data,
     get_ranges_from_policy,
 )
 from .utils import get_msmt_hash, getj, make_submit_request, postj, setup_user
@@ -599,7 +599,7 @@ def make_report_request(probe_cc: str = "IE", probe_asn: str = "AS34245") -> Dic
     }
 
 
-def test_clear_sensible_data_strips_nym_and_zkp_request():
+def test_clear_sensitive_data_strips_nym_and_zkp_request():
     data = {
         "format": "json",
         "content": {"test_name": "web_connectivity"},
@@ -609,7 +609,7 @@ def test_clear_sensible_data_strips_nym_and_zkp_request():
         "manifest_version": "abc123",
     }
 
-    result = _clear_sensible_data(data)
+    result = _clear_sensitive_data(data)
 
     assert "nym" not in result
     assert "zkp_request" not in result
@@ -621,7 +621,7 @@ def test_clear_sensible_data_strips_nym_and_zkp_request():
     }
 
 
-def test_clear_sensible_data_omits_versions():
+def test_clear_sensitive_data_omits_versions():
     data = {
         "format": "json",
         "content": {"test_name": "dummy"},
@@ -629,7 +629,7 @@ def test_clear_sensible_data_omits_versions():
         "zkp_request": "secret-zkp",
     }
 
-    result = _clear_sensible_data(data)
+    result = _clear_sensitive_data(data)
 
     assert "nym" not in result
     assert "zkp_request" not in result

--- a/ooniapi/services/ooniprobe/tests/test_anoncred.py
+++ b/ooniapi/services/ooniprobe/tests/test_anoncred.py
@@ -7,7 +7,10 @@ from fastapi import status
 from ooniauth_py import UserState, ServerState
 from pydantic import ValidationError
 from ooniprobe.dependencies import Manifest, Match, Policy, PolicyEntry
-from ooniprobe.routers.v1.probe_services import get_ranges_from_policy
+from ooniprobe.routers.v1.probe_services import (
+    _clear_sensible_data,
+    get_ranges_from_policy,
+)
 from .utils import get_msmt_hash, getj, make_submit_request, postj, setup_user
 
 @pytest.mark.asyncio
@@ -593,4 +596,46 @@ def make_report_request(probe_cc: str = "IE", probe_asn: str = "AS34245") -> Dic
         "test_name": "web_connectivity",
         "test_start_time": "2020-09-09 14:11:11",
         "test_version": "0.1.0",
+    }
+
+
+def test_clear_sensible_data_strips_nym_and_zkp_request():
+    data = {
+        "format": "json",
+        "content": {"test_name": "web_connectivity"},
+        "nym": "secret-nym",
+        "zkp_request": "secret-zkp",
+        "protocol_version": "0.1.0",
+        "manifest_version": "abc123",
+    }
+
+    result = _clear_sensible_data(data)
+
+    assert "nym" not in result
+    assert "zkp_request" not in result
+    assert result == {
+        "content": data["content"],
+        "format": "json",
+        "protocol_version": "0.1.0",
+        "manifest_version": "abc123",
+    }
+
+
+def test_clear_sensible_data_omits_versions():
+    data = {
+        "format": "json",
+        "content": {"test_name": "dummy"},
+        "nym": "secret-nym",
+        "zkp_request": "secret-zkp",
+    }
+
+    result = _clear_sensible_data(data)
+
+    assert "nym" not in result
+    assert "zkp_request" not in result
+    assert "protocol_version" not in result
+    assert "manifest_version" not in result
+    assert result == {
+        "content": data["content"],
+        "format": "json",
     }

--- a/ooniapi/services/ooniprobe/tests/utils.py
+++ b/ooniapi/services/ooniprobe/tests/utils.py
@@ -42,11 +42,10 @@ def setup_user(client) -> Tuple[UserState, str, int]: # user, manifest version, 
 
 
 def make_submit_request(user: UserState, probe_cc: str, probe_asn: str, msm : str):
-    msm_hash = base64.b64encode(sha256(msm.encode()).digest()).decode()
-    return user.make_submit_request(
+    return user.make_submit_request_with_hash(
         probe_cc,
         probe_asn,
-        msm_hash,
+        msm,
         (2461110, 2826140),
         0,
     )

--- a/ooniapi/services/ooniprobe/tests/utils.py
+++ b/ooniapi/services/ooniprobe/tests/utils.py
@@ -1,5 +1,6 @@
+import base64
 import copy
-from hashlib import sha512
+from hashlib import sha512, sha256
 from httpx import Client
 from typing import Dict, Any
 from fastapi import status
@@ -40,10 +41,12 @@ def setup_user(client) -> Tuple[UserState, str, int]: # user, manifest version, 
     return (user, manifest['meta']['version'], resp['emission_day'])
 
 
-def make_submit_request(user: UserState, probe_cc: str, probe_asn: str):
+def make_submit_request(user: UserState, probe_cc: str, probe_asn: str, msm : str):
+    msm_hash = base64.b64encode(sha256(msm.encode()).digest()).decode()
     return user.make_submit_request(
         probe_cc,
         probe_asn,
+        msm_hash,
         (2461110, 2826140),
         0,
     )


### PR DESCRIPTION
This PR updates the usage of anonymous credentials in measurement submission to bind the measurement verification to the measurement itself 

Now the `server_state.handle_submit` function will take the `content` key part as a string as input for the verification. The library will compute the hash internally, and use that hash to run the verification, see: https://github.com/ooni/userauth/pull/43

Note that this PR will change the request model so that `content` is a string encoding a json rather than a json itself. This is necessary to ensure hash consistency between server and client. 

Also note that we're only hashing the `content` key, rather than the entire request. This is due to the `zkp_request` field part of the metadata, which is computed using the measurement hash, it's impossible to hash the value without first having the value itself.

Another relevant change is that we're removing the extra metadata from the json blob we send to the fastpath. See: 

https://github.com/ooni/backend/pull/1212/changes#diff-ac2bf02692f757bb12106cc9be225fb135ea7aa7308e5d49155836ea1f50caa3R941

Closes #1211 