### PR TITLE
Add geoip fallback to last month's DB

### DIFF
--- a/ooniapi/services/ooniprobe/src/ooniprobe/download_geoip.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/download_geoip.py
@@ -134,6 +134,12 @@ def download_geoip(db_dir: Path, url: str, filename: str) -> None:
     Metrics.GEOIP_DOWNLOAD_TIME.observe(endtime - start_time)
 
 
+def current_geoip_db(db_dir: Path) -> Path | None:
+    if has_valid_geoip_db(db_dir):
+        return db_dir / "asn_cc.mmdb"
+    return None
+
+
 def update_geoip(db_dir: Path, ts: str, asn_cc_url) -> Path:
     db_dir.mkdir(parents=True, exist_ok=True)
     download_geoip(db_dir, asn_cc_url, "asn_cc.mmdb")
@@ -146,23 +152,28 @@ def update_geoip(db_dir: Path, ts: str, asn_cc_url) -> Path:
     return db_dir / "asn_cc.mmdb"
 
 
-def try_update(db_dir: str, max_months_back: int = 1) -> Path | None:
+def try_update(db_dir: str, max_months_back: int = 1) -> tuple[Path | None, bool]:
+    """
+    Returns:
+        (db path, downloaded): path to the currently used database, and whether
+        a new file was downloaded in this call.
+    """
     db_dir_path = Path(db_dir)
     now = datetime.now(timezone.utc)
     current_ts, _, current_url = geoip_release_url(now)
 
     if is_already_updated(db_dir_path, current_ts):
         log.debug("Database already updated. Exiting.")
-        return None
+        return current_geoip_db(db_dir_path), False
 
     if is_latest_available(current_url):
-        return update_geoip(db_dir_path, current_ts, current_url)
+        return update_geoip(db_dir_path, current_ts, current_url), True
 
     if has_valid_geoip_db(db_dir_path):
         log.debug(
             "Current month GeoIP database not available yet; keeping existing database."
         )
-        return None
+        return current_geoip_db(db_dir_path), False
 
     log.warning(
         "No existent geoip found and no new version available: "
@@ -174,7 +185,7 @@ def try_update(db_dir: str, max_months_back: int = 1) -> Path | None:
         ts, _, url = geoip_release_url(release_date)
         if not is_latest_available(url):
             continue
-        return update_geoip(db_dir_path, ts, url)
+        return update_geoip(db_dir_path, ts, url), True
 
     log.debug("No GeoIP update available. Exiting.")
-    return None
+    return None, False

--- a/ooniapi/services/ooniprobe/src/ooniprobe/download_geoip.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/download_geoip.py
@@ -63,7 +63,7 @@ def is_latest_available(url: str) -> bool:
         resp = get_request(url)
         return resp.status == 200
     except HTTPError as err:
-        if resp.status == 404:  # type: ignore
+        if err.status == 404:  # type: ignore
             log.info(f"{url} hasn't been updated yet")
             return False
         log.info(f"unexpected status code '{err.code}' in {url}")

--- a/ooniapi/services/ooniprobe/src/ooniprobe/download_geoip.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/download_geoip.py
@@ -12,6 +12,7 @@ import logging
 import maxminddb
 from pathlib import Path
 from datetime import datetime, timezone
+from dateutil.relativedelta import relativedelta
 from urllib.error import HTTPError
 from urllib.request import urlopen, Request
 
@@ -63,11 +64,32 @@ def is_latest_available(url: str) -> bool:
         resp = get_request(url)
         return resp.status == 200
     except HTTPError as err:
-        if err.status == 404:  # type: ignore
+        if err.code == 404:
             log.info(f"{url} hasn't been updated yet")
             return False
         log.info(f"unexpected status code '{err.code}' in {url}")
         return False
+
+
+def geoip_release_url(release_date: datetime) -> tuple[str, str, str]:
+    ts = release_date.strftime("%Y-%m-01")
+    ver = release_date.strftime("%Y%m01")
+    url = (
+        "https://github.com/ooni/historical-geoip/releases/download/"
+        f"{ver}/{ver}-ip2country_as.mmdb.gz"
+    )
+    return ts, ver, url
+
+
+def has_valid_geoip_db(db_dir: Path) -> bool:
+    db_path = db_dir / "asn_cc.mmdb"
+    if not db_path.exists():
+        return False
+    try:
+        check_geoip_db(db_path)
+    except Exception:
+        return False
+    return True
 
 
 def check_geoip_db(path: Path) -> None:
@@ -119,24 +141,35 @@ def update_geoip(db_dir: Path, ts: str, asn_cc_url) -> None:
     with (db_dir / "geoipdbts").open("w") as out_file:
         out_file.write(ts)
 
-    log.info("Updated GeoIP databases")
+    log.info("Updated GeoIP databases to time: " + ts)
     Metrics.GEOIP_UPDATED.inc()
 
 
-def try_update(db_dir: str):
+def try_update(db_dir: str, max_months_back: int = 1):
     db_dir_path = Path(db_dir)
+    now = datetime.now(timezone.utc)
+    current_ts, _, current_url = geoip_release_url(now)
 
-    ts = datetime.now(timezone.utc).strftime("%Y-%m-01")
-    ver = datetime.now(timezone.utc).strftime("%Y%m01")
-
-    asn_cc_url = f"https://github.com/ooni/historical-geoip/releases/download/{ver}/{ver}-ip2country_as.mmdb.gz"
-
-    if is_already_updated(db_dir_path, ts):
+    if is_already_updated(db_dir_path, current_ts):
         log.debug("Database already updated. Exiting.")
         return
 
-    if not is_latest_available(asn_cc_url):
-        log.debug("Update not available yet. Exiting.")
+    if is_latest_available(current_url):
+        update_geoip(db_dir_path, current_ts, current_url)
         return
 
-    update_geoip(db_dir_path, ts, asn_cc_url)
+    if has_valid_geoip_db(db_dir_path):
+        log.debug(
+            "Current month GeoIP database not available yet; keeping existing database."
+        )
+        return
+
+    for months_back in range(1, max_months_back + 1):
+        release_date = now - relativedelta(months=months_back)
+        ts, _, url = geoip_release_url(release_date)
+        if not is_latest_available(url):
+            continue
+        update_geoip(db_dir_path, ts, url)
+        return
+
+    log.debug("No GeoIP update available. Exiting.")

--- a/ooniapi/services/ooniprobe/src/ooniprobe/download_geoip.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/download_geoip.py
@@ -134,7 +134,7 @@ def download_geoip(db_dir: Path, url: str, filename: str) -> None:
     Metrics.GEOIP_DOWNLOAD_TIME.observe(endtime - start_time)
 
 
-def update_geoip(db_dir: Path, ts: str, asn_cc_url) -> None:
+def update_geoip(db_dir: Path, ts: str, asn_cc_url) -> Path:
     db_dir.mkdir(parents=True, exist_ok=True)
     download_geoip(db_dir, asn_cc_url, "asn_cc.mmdb")
 
@@ -143,26 +143,26 @@ def update_geoip(db_dir: Path, ts: str, asn_cc_url) -> None:
 
     log.info("Updated GeoIP databases to time: " + ts)
     Metrics.GEOIP_UPDATED.inc()
+    return db_dir / "asn_cc.mmdb"
 
 
-def try_update(db_dir: str, max_months_back: int = 1):
+def try_update(db_dir: str, max_months_back: int = 1) -> Path | None:
     db_dir_path = Path(db_dir)
     now = datetime.now(timezone.utc)
     current_ts, _, current_url = geoip_release_url(now)
 
     if is_already_updated(db_dir_path, current_ts):
         log.debug("Database already updated. Exiting.")
-        return
+        return None
 
     if is_latest_available(current_url):
-        update_geoip(db_dir_path, current_ts, current_url)
-        return
+        return update_geoip(db_dir_path, current_ts, current_url)
 
     if has_valid_geoip_db(db_dir_path):
         log.debug(
             "Current month GeoIP database not available yet; keeping existing database."
         )
-        return
+        return None
 
     log.warning(
         "No existent geoip found and no new version available: "
@@ -174,7 +174,7 @@ def try_update(db_dir: str, max_months_back: int = 1):
         ts, _, url = geoip_release_url(release_date)
         if not is_latest_available(url):
             continue
-        update_geoip(db_dir_path, ts, url)
-        return
+        return update_geoip(db_dir_path, ts, url)
 
     log.debug("No GeoIP update available. Exiting.")
+    return None

--- a/ooniapi/services/ooniprobe/src/ooniprobe/download_geoip.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/download_geoip.py
@@ -164,6 +164,11 @@ def try_update(db_dir: str, max_months_back: int = 1):
         )
         return
 
+    log.warning(
+        "No existent geoip found and no new version available: "
+        "falling back to older versions"
+    )
+
     for months_back in range(1, max_months_back + 1):
         release_date = now - relativedelta(months=months_back)
         ts, _, url = geoip_release_url(release_date)

--- a/ooniapi/services/ooniprobe/tests/conftest.py
+++ b/ooniapi/services/ooniprobe/tests/conftest.py
@@ -124,6 +124,22 @@ def last_month_geoip_db(download_geoip_db_dir):
     path.unlink()
 
 
+@pytest.fixture
+def current_month_geoip_db(download_geoip_db_dir):
+    from datetime import datetime, timezone
+
+    from ooniprobe.download_geoip import geoip_release_url
+
+    download_geoip_db_dir.mkdir(parents=True, exist_ok=True)
+    path = download_geoip_db_dir / "asn_cc.mmdb"
+    path.touch()
+    ts, _, _ = geoip_release_url(datetime.now(timezone.utc))
+    (download_geoip_db_dir / "geoipdbts").write_text(ts)
+    yield path
+    path.unlink(missing_ok=True)
+    (download_geoip_db_dir / "geoipdbts").unlink(missing_ok=True)
+
+
 def make_manifest_mock_fn(public_params: str):
     def get_manifest_mock():
         return ManifestResponse(

--- a/ooniapi/services/ooniprobe/tests/conftest.py
+++ b/ooniapi/services/ooniprobe/tests/conftest.py
@@ -117,11 +117,20 @@ def download_geoip_db_dir(tmp_path):
 
 @pytest.fixture
 def last_month_geoip_db(download_geoip_db_dir):
+    from datetime import datetime, timezone
+
+    from dateutil.relativedelta import relativedelta
+    from ooniprobe.download_geoip import geoip_release_url
+
     download_geoip_db_dir.mkdir(parents=True, exist_ok=True)
     path = download_geoip_db_dir / "asn_cc.mmdb"
     path.touch()
+    last_month = datetime.now(timezone.utc) - relativedelta(months=1)
+    ts, _, _ = geoip_release_url(last_month)
+    (download_geoip_db_dir / "geoipdbts").write_text(ts)
     yield path
-    path.unlink()
+    path.unlink(missing_ok=True)
+    (download_geoip_db_dir / "geoipdbts").unlink(missing_ok=True)
 
 
 @pytest.fixture

--- a/ooniapi/services/ooniprobe/tests/conftest.py
+++ b/ooniapi/services/ooniprobe/tests/conftest.py
@@ -110,6 +110,20 @@ def geoip_db_dir(fixture_path):
     return str(ooni_tempdir)
 
 
+@pytest.fixture
+def download_geoip_db_dir(tmp_path):
+    return tmp_path / "geoip"
+
+
+@pytest.fixture
+def last_month_geoip_db(download_geoip_db_dir):
+    download_geoip_db_dir.mkdir(parents=True, exist_ok=True)
+    path = download_geoip_db_dir / "asn_cc.mmdb"
+    path.touch()
+    yield path
+    path.unlink()
+
+
 def make_manifest_mock_fn(public_params: str):
     def get_manifest_mock():
         return ManifestResponse(

--- a/ooniapi/services/ooniprobe/tests/test_download_geoip.py
+++ b/ooniapi/services/ooniprobe/tests/test_download_geoip.py
@@ -1,0 +1,91 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
+
+from ooniprobe.download_geoip import (
+    geoip_release_url,
+    try_update,
+)
+
+FROZEN_NOW = datetime(2026, 6, 15, 12, tzinfo=timezone.utc)
+
+
+def _availability(current: bool, last_month: bool):
+    last_month_date = FROZEN_NOW - relativedelta(months=1)
+    current_url = geoip_release_url(FROZEN_NOW)[2]
+    last_month_url = geoip_release_url(last_month_date)[2]
+
+    def _is_latest_available(url: str) -> bool:
+        if url == current_url:
+            return current
+        if url == last_month_url:
+            return last_month
+        return False
+
+    return _is_latest_available
+
+
+def _patch_is_latest_available(monkeypatch, current: bool, last_month: bool):
+    monkeypatch.setattr(
+        "ooniprobe.download_geoip.is_latest_available",
+        _availability(current, last_month),
+    )
+
+
+def _patch_download_geoip(monkeypatch, urls: set[str]):
+    def _fake_download(db_dir: Path, url: str, filename: str) -> None:
+        assert url in urls
+        db_dir.mkdir(parents=True, exist_ok=True)
+        (db_dir / filename).touch()
+
+    monkeypatch.setattr("ooniprobe.download_geoip.download_geoip", _fake_download)
+
+
+@freeze_time(FROZEN_NOW)
+def test_old_present_new_available(
+    monkeypatch,
+    download_geoip_db_dir,
+    last_month_geoip_db,
+):
+    current_url = geoip_release_url(FROZEN_NOW)[2]
+    _patch_download_geoip(monkeypatch, {current_url})
+    _patch_is_latest_available(monkeypatch, current=True, last_month=False)
+
+    result = try_update(str(download_geoip_db_dir))
+
+    assert result == download_geoip_db_dir / "asn_cc.mmdb"
+    assert (download_geoip_db_dir / "asn_cc.mmdb").exists()
+    assert (download_geoip_db_dir / "geoipdbts").exists()
+
+
+@freeze_time(FROZEN_NOW)
+def test_old_not_present_new_unavailable(
+    monkeypatch,
+    download_geoip_db_dir,
+):
+    last_month = FROZEN_NOW - relativedelta(months=1)
+    last_month_url = geoip_release_url(last_month)[2]
+    _patch_download_geoip(monkeypatch, {last_month_url})
+    _patch_is_latest_available(monkeypatch, current=False, last_month=True)
+
+    result = try_update(str(download_geoip_db_dir))
+
+    assert result == download_geoip_db_dir / "asn_cc.mmdb"
+    assert (download_geoip_db_dir / "asn_cc.mmdb").exists()
+    assert (download_geoip_db_dir / "geoipdbts").exists()
+
+
+@freeze_time(FROZEN_NOW)
+def test_download_nothing_no_db(
+    monkeypatch,
+    download_geoip_db_dir,
+):
+    _patch_is_latest_available(monkeypatch, current=False, last_month=False)
+
+    result = try_update(str(download_geoip_db_dir))
+
+    assert result is None
+    assert not (download_geoip_db_dir / "asn_cc.mmdb").exists()
+    assert not (download_geoip_db_dir / "geoipdbts").exists()

--- a/ooniapi/services/ooniprobe/tests/test_download_geoip.py
+++ b/ooniapi/services/ooniprobe/tests/test_download_geoip.py
@@ -34,9 +34,8 @@ def _patch_is_latest_available(monkeypatch, current: bool, last_month: bool):
     )
 
 
-def _patch_download_geoip(monkeypatch, urls: set[str]):
+def _patch_download_geoip(monkeypatch):
     def _fake_download(db_dir: Path, url: str, filename: str) -> None:
-        assert url in urls
         db_dir.mkdir(parents=True, exist_ok=True)
         (db_dir / filename).touch()
 
@@ -49,8 +48,7 @@ def test_old_present_new_available(
     download_geoip_db_dir,
     last_month_geoip_db,
 ):
-    current_url = geoip_release_url(FROZEN_NOW)[2]
-    _patch_download_geoip(monkeypatch, {current_url})
+    _patch_download_geoip(monkeypatch)
     _patch_is_latest_available(monkeypatch, current=True, last_month=False)
 
     result = try_update(str(download_geoip_db_dir))
@@ -65,9 +63,7 @@ def test_old_not_present_new_unavailable(
     monkeypatch,
     download_geoip_db_dir,
 ):
-    last_month = FROZEN_NOW - relativedelta(months=1)
-    last_month_url = geoip_release_url(last_month)[2]
-    _patch_download_geoip(monkeypatch, {last_month_url})
+    _patch_download_geoip(monkeypatch)
     _patch_is_latest_available(monkeypatch, current=False, last_month=True)
 
     result = try_update(str(download_geoip_db_dir))
@@ -75,6 +71,25 @@ def test_old_not_present_new_unavailable(
     assert result == download_geoip_db_dir / "asn_cc.mmdb"
     assert (download_geoip_db_dir / "asn_cc.mmdb").exists()
     assert (download_geoip_db_dir / "geoipdbts").exists()
+
+
+@freeze_time(FROZEN_NOW)
+def test_old_present_new_unavailable(
+    monkeypatch,
+    download_geoip_db_dir,
+    last_month_geoip_db,
+):
+    monkeypatch.setattr(
+        "ooniprobe.download_geoip.has_valid_geoip_db",
+        lambda db_dir: (db_dir / "asn_cc.mmdb").exists(),
+    )
+    _patch_is_latest_available(monkeypatch, current=False, last_month=False)
+
+    result = try_update(str(download_geoip_db_dir))
+
+    assert result is None
+    assert last_month_geoip_db.exists()
+    assert not (download_geoip_db_dir / "geoipdbts").exists()
 
 
 @freeze_time(FROZEN_NOW)

--- a/ooniapi/services/ooniprobe/tests/test_download_geoip.py
+++ b/ooniapi/services/ooniprobe/tests/test_download_geoip.py
@@ -51,9 +51,10 @@ def test_old_present_new_available(
     _patch_download_geoip(monkeypatch)
     _patch_is_latest_available(monkeypatch, current=True, last_month=False)
 
-    result = try_update(str(download_geoip_db_dir))
+    db_path, downloaded = try_update(str(download_geoip_db_dir))
 
-    assert result == download_geoip_db_dir / "asn_cc.mmdb"
+    assert downloaded is True
+    assert db_path == download_geoip_db_dir / "asn_cc.mmdb"
     assert (download_geoip_db_dir / "asn_cc.mmdb").exists()
     assert (download_geoip_db_dir / "geoipdbts").exists()
 
@@ -66,9 +67,10 @@ def test_old_not_present_new_unavailable(
     _patch_download_geoip(monkeypatch)
     _patch_is_latest_available(monkeypatch, current=False, last_month=True)
 
-    result = try_update(str(download_geoip_db_dir))
+    db_path, downloaded = try_update(str(download_geoip_db_dir))
 
-    assert result == download_geoip_db_dir / "asn_cc.mmdb"
+    assert downloaded is True
+    assert db_path == download_geoip_db_dir / "asn_cc.mmdb"
     assert (download_geoip_db_dir / "asn_cc.mmdb").exists()
     assert (download_geoip_db_dir / "geoipdbts").exists()
 
@@ -85,11 +87,30 @@ def test_old_present_new_unavailable(
     )
     _patch_is_latest_available(monkeypatch, current=False, last_month=False)
 
-    result = try_update(str(download_geoip_db_dir))
+    db_path, downloaded = try_update(str(download_geoip_db_dir))
 
-    assert result is None
+    assert downloaded is False
+    assert db_path == download_geoip_db_dir / "asn_cc.mmdb"
     assert last_month_geoip_db.exists()
     assert not (download_geoip_db_dir / "geoipdbts").exists()
+
+
+@freeze_time(FROZEN_NOW)
+def test_already_updated_current_month(
+    monkeypatch,
+    download_geoip_db_dir,
+    current_month_geoip_db,
+):
+    monkeypatch.setattr(
+        "ooniprobe.download_geoip.has_valid_geoip_db",
+        lambda db_dir: (db_dir / "asn_cc.mmdb").exists(),
+    )
+    db_path, downloaded = try_update(str(download_geoip_db_dir))
+
+    assert downloaded is False
+    assert db_path == download_geoip_db_dir / "asn_cc.mmdb"
+    assert current_month_geoip_db.exists()
+    assert (download_geoip_db_dir / "geoipdbts").exists()
 
 
 @freeze_time(FROZEN_NOW)
@@ -99,8 +120,9 @@ def test_download_nothing_no_db(
 ):
     _patch_is_latest_available(monkeypatch, current=False, last_month=False)
 
-    result = try_update(str(download_geoip_db_dir))
+    db_path, downloaded = try_update(str(download_geoip_db_dir))
 
-    assert result is None
+    assert downloaded is False
+    assert db_path is None
     assert not (download_geoip_db_dir / "asn_cc.mmdb").exists()
     assert not (download_geoip_db_dir / "geoipdbts").exists()

--- a/ooniapi/services/ooniprobe/tests/test_download_geoip.py
+++ b/ooniapi/services/ooniprobe/tests/test_download_geoip.py
@@ -12,6 +12,18 @@ from ooniprobe.download_geoip import (
 FROZEN_NOW = datetime(2026, 6, 15, 12, tzinfo=timezone.utc)
 
 
+def _current_month_ts() -> str:
+    return geoip_release_url(FROZEN_NOW)[0]
+
+
+def _last_month_ts() -> str:
+    return geoip_release_url(FROZEN_NOW - relativedelta(months=1))[0]
+
+
+def _geoipdbts(db_dir: Path) -> str:
+    return (db_dir / "geoipdbts").read_text()
+
+
 def _availability(current: bool, last_month: bool):
     last_month_date = FROZEN_NOW - relativedelta(months=1)
     current_url = geoip_release_url(FROZEN_NOW)[2]
@@ -56,7 +68,7 @@ def test_old_present_new_available(
     assert downloaded is True
     assert db_path == download_geoip_db_dir / "asn_cc.mmdb"
     assert (download_geoip_db_dir / "asn_cc.mmdb").exists()
-    assert (download_geoip_db_dir / "geoipdbts").exists()
+    assert _geoipdbts(download_geoip_db_dir) == _current_month_ts()
 
 
 @freeze_time(FROZEN_NOW)
@@ -72,7 +84,7 @@ def test_old_not_present_new_unavailable(
     assert downloaded is True
     assert db_path == download_geoip_db_dir / "asn_cc.mmdb"
     assert (download_geoip_db_dir / "asn_cc.mmdb").exists()
-    assert (download_geoip_db_dir / "geoipdbts").exists()
+    assert _geoipdbts(download_geoip_db_dir) == _last_month_ts()
 
 
 @freeze_time(FROZEN_NOW)
@@ -91,8 +103,7 @@ def test_old_present_new_unavailable(
 
     assert downloaded is False
     assert db_path == download_geoip_db_dir / "asn_cc.mmdb"
-    assert last_month_geoip_db.exists()
-    assert not (download_geoip_db_dir / "geoipdbts").exists()
+    assert _geoipdbts(download_geoip_db_dir) == _last_month_ts()
 
 
 @freeze_time(FROZEN_NOW)
@@ -109,8 +120,7 @@ def test_already_updated_current_month(
 
     assert downloaded is False
     assert db_path == download_geoip_db_dir / "asn_cc.mmdb"
-    assert current_month_geoip_db.exists()
-    assert (download_geoip_db_dir / "geoipdbts").exists()
+    assert _geoipdbts(download_geoip_db_dir) == _current_month_ts()
 
 
 @freeze_time(FROZEN_NOW)


### PR DESCRIPTION
This PR will add a fallback for last month's DB to the geoip download in case the service is unable to find a proper DB for this month: no new db has been published and no existent db can be used

closes #1213 