### PR TITLE
Fastpath shutdown bug

### DIFF
--- a/fastpath/docker-compose.yml
+++ b/fastpath/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - default
       - all
 
+
   # This service is used only for testing, in prod we use the actual clickhouse db
   clickhouse-server:
     image: clickhouse/clickhouse-server:latest

--- a/fastpath/docker-compose.yml
+++ b/fastpath/docker-compose.yml
@@ -7,10 +7,16 @@ services:
     ports:
       - "5000:5000"
       - "8472:8472"
-    volumes:
-      - .:/app
-    working_dir: /app
+    working_dir: /home/fastpath/app
     command: ["python", "/home/fastpath/app/run_fastpath", "--write-to-disk", "--debug"]
+    develop:
+      watch:
+        - action: sync+restart
+          path: ./fastpath
+          target: /home/fastpath/app/fastpath
+          ignore:
+            - __pycache__/
+            - "*.pyc"
     depends_on:
       clickhouse-server:
         condition: service_healthy

--- a/fastpath/docker-compose.yml
+++ b/fastpath/docker-compose.yml
@@ -3,13 +3,17 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: ooni-fastpath 
+    container_name: ooni-fastpath
     ports:
       - "5000:5000"
       - "8472:8472"
     volumes:
       - .:/app
     working_dir: /app
+    command: ["python", "/home/fastpath/app/run_fastpath", "--write-to-disk", "--debug"]
+    depends_on:
+      clickhouse-server:
+        condition: service_healthy
     profiles:
       - default
       - all
@@ -36,7 +40,7 @@ services:
       timeout: 10s
     profiles:
       - all
-      - clickhouse 
+      - clickhouse
 
 volumes:
   clickhouse-data:

--- a/fastpath/fastpath/core.py
+++ b/fastpath/fastpath/core.py
@@ -1809,6 +1809,7 @@ def core():
 
     # Spawn worker processes
     # 'queue' is a singleton from the portable_queue module
+    parent_pid = os.getpid()
     workers = [
         mp.Process(target=msm_processor, args=(queue,)) for n in range(NUM_WORKERS)
     ]
@@ -1823,6 +1824,10 @@ def core():
         log.exception(e)
 
     finally:
+        # Not a parent PID. Note that gunicorn forks on start_http_api
+        # to create children processes
+        if os.getpid() != parent_pid:
+            return
         log.info("Shutting down workers")
         time.sleep(1)
         shut_down(queue)

--- a/fastpath/fastpath/localhttpfeeder.py
+++ b/fastpath/fastpath/localhttpfeeder.py
@@ -50,5 +50,5 @@ def start_http_api(queue):
         "timeout": WORKER_TIMEOUT,
     }
     print(f"starting localhttpfeeder with worker_timeout: {WORKER_TIMEOUT} and"
-          " queue_put_timeout: {QUEUE_PUT_TIMEOUT}")
+          f" queue_put_timeout: {QUEUE_PUT_TIMEOUT}")
     MsmtFeeder(handler_app, options).run()

--- a/fastpath/fastpath/localhttpfeeder.py
+++ b/fastpath/fastpath/localhttpfeeder.py
@@ -50,5 +50,6 @@ def start_http_api(queue):
         "timeout": WORKER_TIMEOUT,
     }
     print(f"starting localhttpfeeder with worker_timeout: {WORKER_TIMEOUT} and"
-          f" queue_put_timeout: {QUEUE_PUT_TIMEOUT}")
+          f" queue_put_timeout: {QUEUE_PUT_TIMEOUT}", flush=True)
+
     MsmtFeeder(handler_app, options).run()

--- a/fastpath/fastpath/localhttpfeeder.py
+++ b/fastpath/fastpath/localhttpfeeder.py
@@ -48,6 +48,7 @@ def start_http_api(queue):
     options = {
         "bind": f"0.0.0.0:{API_PORT}",
         "timeout": WORKER_TIMEOUT,
+        "control_socket_disable": True,
     }
     print(f"starting localhttpfeeder with worker_timeout: {WORKER_TIMEOUT} and"
           f" queue_put_timeout: {QUEUE_PUT_TIMEOUT}", flush=True)


### PR DESCRIPTION
This PR  will fix a fastpath shutdown bug where gunicorn children processes will try to join worker processes, triggering an exception since gunicorn workers are not parents of worker threads

It will also add some QOL features related to the fastpath docker compose to simplify development: 

- Will enable `watch` features to support hot reloading, see: https://docs.docker.com/compose/how-tos/file-watch/
- It will wait on clickhouse to be ready before starting fastpath 

With the new docker features, you should be able to run everything with: 

```
docker compose --profile all up 
```

closes #1215 