### PR TITLE
Update measurement submission docs regarding metadata

### DIFF
--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
@@ -117,14 +117,16 @@ async def receive_measurement(
     format, the measurement will be rejected
 
     Expected format:
-        - probe_cc = two letters, uppercase, alpha-numeric
-        - probe_asn = AS-prefixed, 3 <= len(probe_asn) <= 12, int value after AS
-        - test_name = 1 <= len(test_name) <= 30, lowercase
+
+    - probe_cc = two letters, uppercase, alpha-numeric
+    - probe_asn = AS-prefixed, 3 <= len(probe_asn) <= 12, int value after AS
+    - test_name = 1 <= len(test_name) <= 30, lowercase
 
     Examples:
-        - probe_cc = `VE`
-        - probe_asn = `AS1234`
-        - test_name = `web_connectivity`
+
+    - probe_cc = `VE`
+    - probe_asn = `AS1234`
+    - test_name = `web_connectivity`
     """
     setnocacheresponse(response)
     empty_measurement = {}

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
@@ -112,6 +112,19 @@ async def receive_measurement(
 ) -> ReceiveMeasurementResponse | Dict[str, Any]:
     """
     Submit measurement.
+
+    If any of probe_cc, asn or test_name metadata has an invalid
+    format, the measurement will be rejected
+
+    Expected format:
+        - probe_cc = two letters, uppercase, alpha-numeric
+        - probe_asn = AS-prefixed, 3 <= len(probe_asn) <= 12, int value after AS
+        - test_name = 1 <= len(test_name) <= 30, lowercase
+
+    Examples:
+        - probe_cc = `VE`
+        - probe_asn = `AS1234`
+        - test_name = `web_connectivity`
     """
     setnocacheresponse(response)
     empty_measurement = {}

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/reports.py
@@ -113,7 +113,7 @@ async def receive_measurement(
     """
     Submit measurement.
 
-    If any of probe_cc, asn or test_name metadata has an invalid
+    If any of probe_cc, probe_asn or test_name metadata has an invalid
     format, the measurement will be rejected
 
     Expected format:

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -895,7 +895,7 @@ async def submit_measurement(
 
     Note that even if `error` is not null in the response, the measurement might still be processed.
 
-    If any of probe_cc, asn or test_name metadata has an invalid
+    If any of probe_cc, probe_asn or test_name metadata has an invalid
     format, the measurement will be rejected
 
     Expected format:

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -895,6 +895,19 @@ async def submit_measurement(
 
     Note that even if `error` is not null in the response, the measurement might still be processed.
 
+    If any of probe_cc, asn or test_name metadata has an invalid
+    format, the measurement will be rejected
+
+    Expected format:
+        - probe_cc = two letters, uppercase, alpha-numeric
+        - probe_asn = AS-prefixed, 3 <= len(probe_asn) <= 12, int value after AS
+        - test_name = 1 <= len(test_name) <= 30, lowercase
+
+    Examples:
+        - probe_cc = `VE`
+        - probe_asn = `AS1234`
+        - test_name = `web_connectivity`
+
     Assume that:
     - status code 2xx: The measurement was processed and stored, even if not verified
     - status code 4xx or 5xx: the measurement was not processed nor stored

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -899,14 +899,16 @@ async def submit_measurement(
     format, the measurement will be rejected
 
     Expected format:
-        - probe_cc = two letters, uppercase, alpha-numeric
-        - probe_asn = AS-prefixed, 3 <= len(probe_asn) <= 12, int value after AS
-        - test_name = 1 <= len(test_name) <= 30, lowercase
+
+    - probe_cc = two letters, uppercase, alpha-numeric
+    - probe_asn = AS-prefixed, 3 <= len(probe_asn) <= 12, int value after AS
+    - test_name = 1 <= len(test_name) <= 30, lowercase
 
     Examples:
-        - probe_cc = `VE`
-        - probe_asn = `AS1234`
-        - test_name = `web_connectivity`
+
+    - probe_cc = `VE`
+    - probe_asn = `AS1234`
+    - test_name = `web_connectivity`
 
     Assume that:
     - status code 2xx: The measurement was processed and stored, even if not verified


### PR DESCRIPTION
This PR just adds extra documentation to the measurement submission endpoint regarding expected formats for metadata fields 