### PR TITLE
Fix broken geoip download tests

### DIFF
--- a/ooniapi/services/ooniprobe/tests/conftest.py
+++ b/ooniapi/services/ooniprobe/tests/conftest.py
@@ -119,7 +119,11 @@ def download_geoip_db_dir(tmp_path):
 GEOIP_FROZEN_TIME = datetime(2026, 6, 15, 12, tzinfo=timezone.utc)
 @pytest.fixture
 def frozen_time():
-    # Used for geoip download tests
+    """
+    Used for geoip download tests.
+
+    This function will freeze the time for fixtures that have it as dependency
+    """
     with freeze_time(GEOIP_FROZEN_TIME) as ft:
         yield ft
 

--- a/ooniapi/services/ooniprobe/tests/conftest.py
+++ b/ooniapi/services/ooniprobe/tests/conftest.py
@@ -1,8 +1,9 @@
+from freezegun import freeze_time
 import json
 import pathlib
 import time
 from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict
 from urllib.request import urlopen
@@ -114,9 +115,16 @@ def geoip_db_dir(fixture_path):
 def download_geoip_db_dir(tmp_path):
     return tmp_path / "geoip"
 
+# A date used on several geoip tests:
+GEOIP_FROZEN_TIME = datetime(2026, 6, 15, 12, tzinfo=timezone.utc)
+@pytest.fixture
+def frozen_time():
+    # Used for geoip download tests
+    with freeze_time(GEOIP_FROZEN_TIME) as ft:
+        yield ft
 
 @pytest.fixture
-def last_month_geoip_db(download_geoip_db_dir):
+def last_month_geoip_db(frozen_time, download_geoip_db_dir):
     from datetime import datetime, timezone
 
     from dateutil.relativedelta import relativedelta
@@ -134,7 +142,7 @@ def last_month_geoip_db(download_geoip_db_dir):
 
 
 @pytest.fixture
-def current_month_geoip_db(download_geoip_db_dir):
+def current_month_geoip_db(frozen_time, download_geoip_db_dir):
     from datetime import datetime, timezone
 
     from ooniprobe.download_geoip import geoip_release_url

--- a/ooniapi/services/ooniprobe/tests/test_download_geoip.py
+++ b/ooniapi/services/ooniprobe/tests/test_download_geoip.py
@@ -53,8 +53,8 @@ def _patch_download_geoip(monkeypatch):
     monkeypatch.setattr("ooniprobe.download_geoip.download_geoip", _fake_download)
 
 
-@freeze_time(GEOIP_FROZEN_TIME)
 def test_old_present_new_available(
+    frozen_time,
     monkeypatch,
     download_geoip_db_dir,
     last_month_geoip_db,
@@ -70,8 +70,8 @@ def test_old_present_new_available(
     assert _geoipdbts(download_geoip_db_dir) == _current_month_ts()
 
 
-@freeze_time(GEOIP_FROZEN_TIME)
 def test_old_not_present_new_unavailable(
+    frozen_time,
     monkeypatch,
     download_geoip_db_dir,
 ):
@@ -86,8 +86,8 @@ def test_old_not_present_new_unavailable(
     assert _geoipdbts(download_geoip_db_dir) == _last_month_ts()
 
 
-@freeze_time(GEOIP_FROZEN_TIME)
 def test_old_present_new_unavailable(
+    frozen_time,
     monkeypatch,
     download_geoip_db_dir,
     last_month_geoip_db,
@@ -105,8 +105,8 @@ def test_old_present_new_unavailable(
     assert _geoipdbts(download_geoip_db_dir) == _last_month_ts()
 
 
-@freeze_time(GEOIP_FROZEN_TIME)
 def test_already_updated_current_month(
+    frozen_time,
     monkeypatch,
     download_geoip_db_dir,
     current_month_geoip_db,
@@ -122,8 +122,8 @@ def test_already_updated_current_month(
     assert _geoipdbts(download_geoip_db_dir) == _current_month_ts()
 
 
-@freeze_time(GEOIP_FROZEN_TIME)
 def test_download_nothing_no_db(
+    frozen_time,
     monkeypatch,
     download_geoip_db_dir,
 ):

--- a/ooniapi/services/ooniprobe/tests/test_download_geoip.py
+++ b/ooniapi/services/ooniprobe/tests/test_download_geoip.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from tests.conftest import GEOIP_FROZEN_TIME
 from pathlib import Path
 
 from dateutil.relativedelta import relativedelta
@@ -9,15 +9,14 @@ from ooniprobe.download_geoip import (
     try_update,
 )
 
-FROZEN_NOW = datetime(2026, 6, 15, 12, tzinfo=timezone.utc)
 
 
 def _current_month_ts() -> str:
-    return geoip_release_url(FROZEN_NOW)[0]
+    return geoip_release_url(GEOIP_FROZEN_TIME)[0]
 
 
 def _last_month_ts() -> str:
-    return geoip_release_url(FROZEN_NOW - relativedelta(months=1))[0]
+    return geoip_release_url(GEOIP_FROZEN_TIME- relativedelta(months=1))[0]
 
 
 def _geoipdbts(db_dir: Path) -> str:
@@ -25,8 +24,8 @@ def _geoipdbts(db_dir: Path) -> str:
 
 
 def _availability(current: bool, last_month: bool):
-    last_month_date = FROZEN_NOW - relativedelta(months=1)
-    current_url = geoip_release_url(FROZEN_NOW)[2]
+    last_month_date = GEOIP_FROZEN_TIME - relativedelta(months=1)
+    current_url = geoip_release_url(GEOIP_FROZEN_TIME)[2]
     last_month_url = geoip_release_url(last_month_date)[2]
 
     def _is_latest_available(url: str) -> bool:
@@ -54,7 +53,7 @@ def _patch_download_geoip(monkeypatch):
     monkeypatch.setattr("ooniprobe.download_geoip.download_geoip", _fake_download)
 
 
-@freeze_time(FROZEN_NOW)
+@freeze_time(GEOIP_FROZEN_TIME)
 def test_old_present_new_available(
     monkeypatch,
     download_geoip_db_dir,
@@ -71,7 +70,7 @@ def test_old_present_new_available(
     assert _geoipdbts(download_geoip_db_dir) == _current_month_ts()
 
 
-@freeze_time(FROZEN_NOW)
+@freeze_time(GEOIP_FROZEN_TIME)
 def test_old_not_present_new_unavailable(
     monkeypatch,
     download_geoip_db_dir,
@@ -87,7 +86,7 @@ def test_old_not_present_new_unavailable(
     assert _geoipdbts(download_geoip_db_dir) == _last_month_ts()
 
 
-@freeze_time(FROZEN_NOW)
+@freeze_time(GEOIP_FROZEN_TIME)
 def test_old_present_new_unavailable(
     monkeypatch,
     download_geoip_db_dir,
@@ -106,7 +105,7 @@ def test_old_present_new_unavailable(
     assert _geoipdbts(download_geoip_db_dir) == _last_month_ts()
 
 
-@freeze_time(FROZEN_NOW)
+@freeze_time(GEOIP_FROZEN_TIME)
 def test_already_updated_current_month(
     monkeypatch,
     download_geoip_db_dir,
@@ -123,7 +122,7 @@ def test_already_updated_current_month(
     assert _geoipdbts(download_geoip_db_dir) == _current_month_ts()
 
 
-@freeze_time(FROZEN_NOW)
+@freeze_time(GEOIP_FROZEN_TIME)
 def test_download_nothing_no_db(
     monkeypatch,
     download_geoip_db_dir,


### PR DESCRIPTION
The problem was that the decorator we use to fix the date in tests only applies to code called from within the function body. Fixtures are not affected by the decorator because they are computed before calling the decorated function

closes #1222 