### PR TITLE
Profiling middleware

### DIFF
--- a/ooniapi/common/src/common/config.py
+++ b/ooniapi/common/src/common/config.py
@@ -106,3 +106,7 @@ class Settings(BaseSettings):
     github_token: str = ""
     origin_repo: str = ""
     push_repo: str = ""
+
+    # Profiling settings
+    profiling_active: bool = False
+    profiling_report_path: str = ""

--- a/ooniapi/common/src/common/profile_middleware.py
+++ b/ooniapi/common/src/common/profile_middleware.py
@@ -2,7 +2,9 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 from pathlib import Path
+import logging
 
+log = logging.getLogger(__name__)
 
 class ProfileMiddleware(BaseHTTPMiddleware):
     """
@@ -28,6 +30,8 @@ class ProfileMiddleware(BaseHTTPMiddleware):
         # Pyinstrument is only available on development modes
         from pyinstrument import Profiler
 
+        log.debug(f"Profiling: {request.url.path}")
+
         profiler = Profiler()
         profiler.start()
         response = await call_next(request)
@@ -41,6 +45,7 @@ class ProfileMiddleware(BaseHTTPMiddleware):
 
         with report_path.open("w") as f:
             f.write(report)
+            log.debug(f"Report saved to: {report_path.absolute()}")
 
         return response
 

--- a/ooniapi/common/src/common/profile_middleware.py
+++ b/ooniapi/common/src/common/profile_middleware.py
@@ -9,14 +9,20 @@ class ProfileMiddleware(BaseHTTPMiddleware):
     Profiles a request, generating an html report on disk
     """
 
-    def __init__(self, app, profiling_active : bool, report_path : str):
+    def __init__(self, app, profiling_active : bool, report_path : str, whitelist: tuple[str]):
+        """
+        - profiling_active: whether profiling is enabled
+        - report_path: local disk path where the report is written
+        - whitelist: path prefixes to profile (only matching requests are profiled)
+        """
         super().__init__(app)
         self.profiling_active = profiling_active
         self.report_path = report_path
+        self.whitelist = whitelist
 
     async def dispatch(self, request: Request, call_next) -> Response:
 
-        if not self.profiling_active:
+        if not self.profiling_active or not self.should_profile(request):
             return await call_next(request)
 
         # Pyinstrument is only available on development modes
@@ -37,3 +43,6 @@ class ProfileMiddleware(BaseHTTPMiddleware):
             f.write(report)
 
         return response
+
+    def should_profile(self, request: Request) -> bool:
+        return request.url.path.startswith(self.whitelist)

--- a/ooniapi/common/src/common/profile_middleware.py
+++ b/ooniapi/common/src/common/profile_middleware.py
@@ -1,0 +1,39 @@
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from pathlib import Path
+
+
+class ProfileMiddleware(BaseHTTPMiddleware):
+    """
+    Profiles a request, generating an html report on disk
+    """
+
+    def __init__(self, app, profiling_active : bool, report_path : str):
+        super().__init__(app)
+        self.profiling_active = profiling_active
+        self.report_path = report_path
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+
+        if not self.profiling_active:
+            return await call_next(request)
+
+        # Pyinstrument is only available on development modes
+        from pyinstrument import Profiler
+
+        profiler = Profiler()
+        profiler.start()
+        response = await call_next(request)
+        profiler.stop()
+
+        # Save report to a file
+        report = profiler.output_html()
+        report_path = Path(self.report_path)
+        report_path.parent.mkdir(exist_ok=True)
+        report_path.touch(exist_ok=True)
+
+        with report_path.open("w") as f:
+            f.write(report)
+
+        return response

--- a/ooniapi/common/src/common/profile_middleware.py
+++ b/ooniapi/common/src/common/profile_middleware.py
@@ -11,20 +11,18 @@ class ProfileMiddleware(BaseHTTPMiddleware):
     Profiles a request, generating an html report on disk
     """
 
-    def __init__(self, app, profiling_active : bool, report_path : str, whitelist: tuple[str]):
+    def __init__(self, app, report_path : str, whitelist: tuple[str]):
         """
-        - profiling_active: whether profiling is enabled
         - report_path: local disk path where the report is written
         - whitelist: path prefixes to profile (only matching requests are profiled)
         """
         super().__init__(app)
-        self.profiling_active = profiling_active
         self.report_path = report_path
         self.whitelist = whitelist
 
     async def dispatch(self, request: Request, call_next) -> Response:
 
-        if not self.profiling_active or not self.should_profile(request):
+        if not self.should_profile(request):
             return await call_next(request)
 
         # Pyinstrument is only available on development modes

--- a/ooniapi/services/ooniprobe/pyproject.toml
+++ b/ooniapi/services/ooniprobe/pyproject.toml
@@ -75,6 +75,7 @@ dependencies = [
   "pytest-asyncio",
   "freezegun",
   "pytest-docker",
+  "pyinstrument"
 ]
 path = ".venv/"
 

--- a/ooniapi/services/ooniprobe/src/ooniprobe/main.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/main.py
@@ -15,6 +15,7 @@ from starlette.concurrency import run_in_threadpool
 
 from . import models
 from .__about__ import VERSION
+from .common.profile_middleware import ProfileMiddleware
 from .common.clickhouse_utils import query_click
 from .common.config import Settings
 from .common.dependencies import ClickhouseDep, SettingsDep, get_settings
@@ -85,6 +86,14 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+)
+
+settings = get_settings()
+app.add_middleware(
+    ProfileMiddleware,
+    profile_active = settings.profiling_active,
+    report_path = settings.profiling_report_path,
+    whitelist = ("/api/v1/submit_measurement",)
 )
 
 app.include_router(vpn.router, prefix="/api")
@@ -185,6 +194,14 @@ async def health(
         "version": VERSION,
         "build_label": build_label,
     }
+
+    if settings.profiling_active:
+        try:
+            import pyinstrument  # noqa: F401
+        except ImportError:
+            # In case we set profiling active in a profile that doesn't includes
+            # development tools
+            errors.append("profiling_active_without_pyinstrument")
 
     if len(errors):
         log.error(f"Health check errors detected: {errors}")

--- a/ooniapi/services/ooniprobe/src/ooniprobe/main.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/main.py
@@ -91,7 +91,7 @@ app.add_middleware(
 settings = get_settings()
 app.add_middleware(
     ProfileMiddleware,
-    profile_active = settings.profiling_active,
+    profiling_active = settings.profiling_active,
     report_path = settings.profiling_report_path,
     whitelist = ("/api/v1/submit_measurement",)
 )

--- a/ooniapi/services/ooniprobe/src/ooniprobe/main.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/main.py
@@ -89,12 +89,12 @@ app.add_middleware(
 )
 
 settings = get_settings()
-app.add_middleware(
-    ProfileMiddleware,
-    profiling_active = settings.profiling_active,
-    report_path = settings.profiling_report_path,
-    whitelist = ("/api/v1/submit_measurement",)
-)
+if settings.profiling_active:
+    app.add_middleware(
+        ProfileMiddleware,
+        report_path = settings.profiling_report_path,
+        whitelist = ("/api/v1/submit_measurement",)
+    )
 
 app.include_router(vpn.router, prefix="/api")
 app.include_router(probe_services.router, prefix="/api")

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -1038,7 +1038,7 @@ async def submit_measurement(
 
     # wasn't possible to send msmnt to fastpath, try to send it to s3
     ts_prefix = now.strftime("%Y%m%d%H")
-    s3_key = f"postcans/{ts_prefix}/{ts_prefix}_{cc}_{tn}/{msmt_uid}.post"
+    s3_key = f"postcans/{ts_prefix}/{ts_prefix}_{cc}_{test_name}/{msmt_uid}.post"
     try:
         await run_in_threadpool(
             request.app.state.s3_client.upload_fileobj,

--- a/ooniapi/services/ooniprobe/tests/conftest.py
+++ b/ooniapi/services/ooniprobe/tests/conftest.py
@@ -19,6 +19,7 @@ import pytest_asyncio
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from ooniprobe.common.profile_middleware import ProfileMiddleware
 from ooniprobe.common.clickhouse_utils import insert_click
 from ooniprobe.common.config import Settings
 from ooniprobe.common.dependencies import get_settings
@@ -35,7 +36,7 @@ from ooniprobe.download_geoip import try_update
 from ooniprobe.main import app, lifespan
 from ooniprobe.routers.v1.probe_services import TorTarget
 
-from .utils import setup_user
+from .utils import setup_user, set_middleware_params
 
 
 def make_override_get_settings(**kw):
@@ -461,3 +462,28 @@ async def client_with_two_working_fastpaths(
         test_settings, geoip_db_dir, test_creds, [first_url, second_url]
     ) as (client, mock_fastpath):
         yield client, mock_fastpath, first_url, second_url
+
+
+@pytest_asyncio.fixture(scope='function')
+def profiling_enabled(tmp_path):
+    old = set_middleware_params(app, ProfileMiddleware,
+        profiling_active = True,
+        report_path = str(tmp_path / "report.html"),
+        whitelist = ("/api/v1/manifest",)
+    ) or {}
+
+    yield
+
+    set_middleware_params(app, ProfileMiddleware, **old)
+
+@pytest_asyncio.fixture(scope='function')
+def profiling_disabled(tmp_path):
+    old = set_middleware_params(app, ProfileMiddleware,
+        profiling_active = False,
+        report_path = str(tmp_path / "report.html"),
+        whitelist = ("/api/v1/manifest",)
+    ) or {}
+
+    yield
+
+    set_middleware_params(app, ProfileMiddleware, **old)

--- a/ooniapi/services/ooniprobe/tests/conftest.py
+++ b/ooniapi/services/ooniprobe/tests/conftest.py
@@ -36,7 +36,7 @@ from ooniprobe.download_geoip import try_update
 from ooniprobe.main import app, lifespan
 from ooniprobe.routers.v1.probe_services import TorTarget
 
-from .utils import setup_user, set_middleware_params
+from .utils import setup_user, add_test_middleware, remove_test_middleware
 
 
 def make_override_get_settings(**kw):
@@ -466,24 +466,13 @@ async def client_with_two_working_fastpaths(
 
 @pytest_asyncio.fixture(scope='function')
 def profiling_enabled(tmp_path):
-    old = set_middleware_params(app, ProfileMiddleware,
-        profiling_active = True,
+    # The app only registers ProfileMiddleware when profiling is active, so
+    # tests that want profiling behavior must add it themselves.
+    add_test_middleware(app, ProfileMiddleware,
         report_path = str(tmp_path / "report.html"),
         whitelist = ("/api/v1/manifest",)
-    ) or {}
+    )
 
     yield
 
-    set_middleware_params(app, ProfileMiddleware, **old)
-
-@pytest_asyncio.fixture(scope='function')
-def profiling_disabled(tmp_path):
-    old = set_middleware_params(app, ProfileMiddleware,
-        profiling_active = False,
-        report_path = str(tmp_path / "report.html"),
-        whitelist = ("/api/v1/manifest",)
-    ) or {}
-
-    yield
-
-    set_middleware_params(app, ProfileMiddleware, **old)
+    remove_test_middleware(app, ProfileMiddleware)

--- a/ooniapi/services/ooniprobe/tests/test_profiling_middleware.py
+++ b/ooniapi/services/ooniprobe/tests/test_profiling_middleware.py
@@ -1,0 +1,24 @@
+from .utils import getj
+import pytest
+from pathlib import Path
+
+
+@pytest.mark.asyncio
+async def test_profiling_enabled(client, db, tmp_path, profiling_enabled):
+    report_path: Path = tmp_path / "report.html"
+
+    assert not report_path.exists()
+
+    getj(client, "/api/v1/manifest")
+
+    assert report_path.exists()
+
+@pytest.mark.asyncio
+async def test_profiling_disabled(client, db, tmp_path, profiling_disabled):
+    report_path: Path = tmp_path / "report.html"
+
+    assert not report_path.exists()
+
+    getj(client, "/api/v1/manifest")
+
+    assert not report_path.exists()

--- a/ooniapi/services/ooniprobe/tests/test_profiling_middleware.py
+++ b/ooniapi/services/ooniprobe/tests/test_profiling_middleware.py
@@ -14,7 +14,7 @@ async def test_profiling_enabled(client, db, tmp_path, profiling_enabled):
     assert report_path.exists()
 
 @pytest.mark.asyncio
-async def test_profiling_disabled(client, db, tmp_path, profiling_disabled):
+async def test_profiling_disabled(client, db, tmp_path):
     report_path: Path = tmp_path / "report.html"
 
     assert not report_path.exists()

--- a/ooniapi/services/ooniprobe/tests/utils.py
+++ b/ooniapi/services/ooniprobe/tests/utils.py
@@ -55,3 +55,13 @@ def get_msmt_hash(msmt: Dict[str, Any], is_verified: str = "u") -> str:
     payload = copy.deepcopy(msmt)
     payload["is_verified"] = is_verified
     return sha512(ujson.dumps(payload).encode()).hexdigest()[:16]
+
+def set_middleware_params(app, middleware_class, **kwargs):
+    old = None
+    for m in app.user_middleware:
+        if m.cls is middleware_class:
+            old = m.options.copy()
+            m.options.update(kwargs)
+            app.middleware_stack = None  # force Starlette to rebuild on next request
+            break
+    return old

--- a/ooniapi/services/ooniprobe/tests/utils.py
+++ b/ooniapi/services/ooniprobe/tests/utils.py
@@ -56,12 +56,21 @@ def get_msmt_hash(msmt: Dict[str, Any], is_verified: str = "u") -> str:
     payload["is_verified"] = is_verified
     return sha512(ujson.dumps(payload).encode()).hexdigest()[:16]
 
-def set_middleware_params(app, middleware_class, **kwargs):
-    old = None
-    for m in app.user_middleware:
-        if m.cls is middleware_class:
-            old = m.options.copy()
-            m.options.update(kwargs)
-            app.middleware_stack = None  # force Starlette to rebuild on next request
-            break
-    return old
+def add_test_middleware(app, middleware_class, **kwargs):
+    """
+    Add a middleware for the duration of a test, even if the app does not
+    normally register it (e.g. it's conditionally added based on settings).
+
+    The app's middleware stack is reset so Starlette rebuilds it on the next
+    request. Call `remove_test_middleware` during teardown to undo this.
+    """
+    app.middleware_stack = None
+    app.add_middleware(middleware_class, **kwargs)
+
+
+def remove_test_middleware(app, middleware_class):
+    """Undo `add_test_middleware`."""
+    app.user_middleware = [
+        m for m in app.user_middleware if m.cls is not middleware_class
+    ]
+    app.middleware_stack = None


### PR DESCRIPTION
Adds a profiling middleware that generates HTML reports of the specified endpoints, using [pyinstrument](https://pypi.org/project/pyinstrument/3.0.0b3/)

Some examples: 
<img width="1915" height="325" alt="image" src="https://github.com/user-attachments/assets/9e335187-e03c-4789-b56c-17e5efe74f3d" />
<img width="1906" height="500" alt="image" src="https://github.com/user-attachments/assets/9a40fc1d-3408-4e4f-bc35-58d817ecad6a" />


This is specially useful for diagnosing performance issues, particularly the new submission path that has been showing poor performance 

# Usage 

We have now exposed two new environment variables: 
- PROFILING_ACTIVE = (default: false) Sets profiling active or unactive 
- PROFILE_REPORT_PATH = (default: empty string) The path where the HTML report will be saved to 

To specify what endpoints should be profiled, use the `whitelist` list of accepted prefixes: 
https://github.com/ooni/backend/blob/78042327342ee8759d8579a7c80f00ee321e3517/ooniapi/services/ooniprobe/src/ooniprobe/main.py#L96