### PR TITLE
Run verification in threadpool

### DIFF
--- a/ooniapi/services/ooniprobe/pyproject.toml
+++ b/ooniapi/services/ooniprobe/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "boto3 ~= 1.39.3",
   "boto3-stubs[s3] ~= 1.39.3",
   "mypy-boto3-s3 ~= 1.39.5",
-  "ooniauth-py==0.3.2"
+  "ooniauth-py==0.3.3"
 ]
 
 readme = "README.md"

--- a/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
+++ b/ooniapi/services/ooniprobe/src/ooniprobe/routers/v1/probe_services.py
@@ -944,7 +944,8 @@ async def submit_measurement(
     rid = generate_report_id(test_name, settings, cc, normalize_asn(asn))
 
     # Anonymous credentials verification
-    verification_status, submit_error, submit_response = _verify_submit(
+    verification_status, submit_error, submit_response = await run_in_threadpool(
+        _verify_submit,
         submit_request, manifest, settings,
         content.get('probe_cc'), content.get('probe_asn')
     )


### PR DESCRIPTION
This PR will move verification of anonymous credentials to the threadpool

Now that https://github.com/ooni/userauth/pull/48 is merged, verifications should be able to run in parallel instead of locking the threadpool with CPU bound operations  