### PR TITLE
Improve oonifinding fetching docs

### DIFF
--- a/ooniapi/services/oonifindings/src/oonifindings/routers/v1.py
+++ b/ooniapi/services/oonifindings/src/oonifindings/routers/v1.py
@@ -232,7 +232,10 @@ def get_oonifinding_by_id(
     authorization: str = Header("authorization"),
 ):
     """
-    Returns an incident
+    Returns an incident by id.
+
+    It supports **fetching by slug**, if the provided id is an integer, we
+    assume it's an id. Otherwise we assume it's the slug.
     """
     log.debug("showing incident")
 


### PR DESCRIPTION
Fetching findings by slug was already implemented (see #1232) but not documented in API docs, that's why we thought it wasn't. 

This PR updates the docs of the `/api/v1/incidents/show/{finding_id}` endpoint to specify that fetching by slug is possible

closes #1232 