### PR TITLE
Update container to debian 13; debian 11 is EOL

### DIFF
--- a/.github/workflows/test_fastpath.yml
+++ b/.github/workflows/test_fastpath.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: debian:11
+    container: debian:13
     steps:
       - uses: actions/checkout@v2
       - name: Install deps


### PR DESCRIPTION
CI fails as debian 11 image is deprecated as of 2 days ago